### PR TITLE
Add logfire service & security context

### DIFF
--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -45,6 +45,44 @@ logfire-frontend:
       value: https://dex.example.com
 ```
 
+### Ingress
+
+We have an ingress configuration that will allow you to set up ingress:
+
+```yaml
+ingress:
+  enabled: true
+  tls: true
+  apiHostname: logfire-api.example.com
+  frontendHostname: logfire.example.com
+  ingressClassName: nginx
+```
+
+#### Using the direct service
+
+We expose a service called `logfire-service` which will route traffic appropriately.
+
+If you don't want to use the ingress controller, you will still need to define hostnames and whether you are externally using TLS:
+
+I.e, this config will turn off the ingress resource, but still set appropriate cors headers for the `logfire-service`:
+
+```yaml
+ingress:
+  # this turns off the ingress resource
+  enabled: false
+  # used to ensure appropriate CORS headers are set.  If your browser is accessing it on https, then needs to be enabled here
+  tls: true
+  # used to ensure appropriate CORS headers are set. 
+  apiHostname: logfire-api.k3s.local
+  # used to ensure appropriate CORS headers are set.
+  frontendHostname: logfire.k3s.local
+```
+
+If you are *not* using kubernetes ingress, you must still set the hostnames under the `ingress` configuration.
+
+
+
+
 ### Dex
 
 Dex is used as the identity service for logfire & can be configured for many different types of connectors.  The full list of connectors can be found here: [https://dexidp.io/docs/connectors/](https://dexidp.io/docs/connectors/)
@@ -85,6 +123,9 @@ dex:
         logfire_frontend_host: https://logfire.example.com
 ```
 
+Note that the `staticClients.id` MUST match the `LOGFIRE_CLIENT_ID` in the backend configuration.
+We recommend you use `logfire-backend` and do not change this value for simplicity.
+
 #### Authentication Configuration
 
 Depending on what [connector you want to use](https://dexidp.io/docs/connectors/), you can configure dex connectors accordingly.
@@ -123,6 +164,16 @@ dex:
           redirectURI: `https://dex.example.com/dex/callback`
           useLoginAsID: false
           getUserInfo: true
+```
+#### Image pull secrets
+
+Remember to add the image pull secrets to dex's service account `logfire-dex` or add the pull secrets directly to the dex config:
+
+```yaml
+dex:
+  imagePullSecrets:
+    - name: logfire-image-key
+  config:
 ```
 
 We recommend you set secrets as Kubernetes secrets and reference them in the `values.yaml` file instead of hardcoding secrets which is more likely to be exposed and harder to rotate.
@@ -278,6 +329,20 @@ See [`values.yaml`](./values.yaml) for some production level values
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+## Configuring Logfire
+
+Since this is self-hosted you will need to update your logfire configuration to include a different URL to send data to.  You can do this by specifying the `base_url` in advanced config:
+
+```python
+import logfire
+
+logfire.configure(
+    token='<your_logfire_token>',
+    advanced=logfire.AdvancedOptions(base_url="https://logfire-api.example.com")
+)
+logfire.info('Hello, {place}!', place='World')
+```
 
 ## Development
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -52,7 +52,7 @@ resources:
 {{- end}}
 
 {{- define "logfire.frontend" -}}
-"{{ .Values.ingress.tls | default false | ternary "https" "http" }}://{{ .Values.ingress.frontendHostname }}"
+{{ .Values.ingress.tls | default false | ternary "https" "http" }}://{{ .Values.ingress.frontendHostname }}
 {{- end -}}
 
 {{/*

--- a/chart/templates/logfire-api-ingress.yaml
+++ b/chart/templates/logfire-api-ingress.yaml
@@ -17,36 +17,13 @@ spec:
     - host: {{ .Values.ingress.apiHostname }}
       http:
         paths:
-        # Route for /v1/traces, /v1/metrics, and /v1/logs
-          - path: /v1/traces
-            pathType: Exact
-            backend:
-              service:
-                name: logfire-ff-ingest-api
-                port:
-                  number: 8012
-          - path: /v1/metrics
-            pathType: Exact
-            backend:
-              service:
-                name: logfire-ff-ingest-api
-                port:
-                  number: 8012
-          - path: /v1/logs
-            pathType: Exact
-            backend:
-              service:
-                name: logfire-ff-ingest-api
-                port:
-                  number: 8012
-          # Default route for all other traffic
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: logfire-backend
+                name: logfire-service
                 port:
-                  number: 8000
+                  number: 80
   {{- if .Values.ingress.tls }}
   tls:
     - secretName: logfire-api-cert
@@ -76,9 +53,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: logfire-frontend
+                name: logfire-service
                 port:
-                  number: 3000
+                  number: 80
   {{- if .Values.ingress.tls }}
   tls:
     - secretName: logfire-frontend-cert

--- a/chart/templates/logfire-backend.yaml
+++ b/chart/templates/logfire-backend.yaml
@@ -49,8 +49,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
@@ -105,7 +109,7 @@ spec:
             - name: LOGFIRE_REGION
               value: {{ .Values.logfireRegion | default "us" }}
             - name: FRONTEND_HOST
-              value: {{ include "logfire.frontend" . }}
+              value: {{ include "logfire.frontend" . | quote }}
             - name: META_WRITE_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/logfire-ff-cache.yaml
+++ b/chart/templates/logfire-ff-cache.yaml
@@ -35,8 +35,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-ff-conhash-cache.yaml
+++ b/chart/templates/logfire-ff-conhash-cache.yaml
@@ -82,8 +82,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-ff-ingest-api.yaml
+++ b/chart/templates/logfire-ff-ingest-api.yaml
@@ -50,8 +50,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-ff-ingest-worker.yaml
+++ b/chart/templates/logfire-ff-ingest-worker.yaml
@@ -34,8 +34,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-ff-maintenance-worker.yaml
+++ b/chart/templates/logfire-ff-maintenance-worker.yaml
@@ -34,8 +34,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
 {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | indent 10 }}

--- a/chart/templates/logfire-ff-query-api.yaml
+++ b/chart/templates/logfire-ff-query-api.yaml
@@ -50,8 +50,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-ff-query-worker.yaml
+++ b/chart/templates/logfire-ff-query-worker.yaml
@@ -35,8 +35,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-frontend.yaml
+++ b/chart/templates/logfire-frontend.yaml
@@ -47,8 +47,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.frontendImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-otel-collector.yaml
+++ b/chart/templates/logfire-otel-collector.yaml
@@ -104,6 +104,8 @@ spec:
       {{- range . }}
         - name: {{ . | quote }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       {{- with (index .Values $serviceName | default dict).initContainers }}
       initContainers:

--- a/chart/templates/logfire-scheduler.yaml
+++ b/chart/templates/logfire-scheduler.yaml
@@ -33,8 +33,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.schedulerImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}

--- a/chart/templates/logfire-service.yaml
+++ b/chart/templates/logfire-service.yaml
@@ -1,0 +1,185 @@
+{{- $serviceName := "logfire-service" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+spec:
+  selector:
+    {{- include "logfire.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+data:
+  nginx.conf: |
+    events {}
+    
+    http {
+        server {
+            server_name {{ .Values.ingress.apiHostname }};
+            listen 80;
+
+            # Proxy /v1/traces and /v1/metrics to fusionfire-ingest-api
+            location ~ ^/v1/(traces|metrics|logs)$ {
+
+                if ($request_method = 'OPTIONS') {
+                    add_header 'Access-Control-Allow-Origin' '{{ include "logfire.frontend" . }}' always;
+                    add_header 'Access-Control-Allow-Credentials' 'true' always;
+                    add_header 'Access-Control-Allow-Methods' '*' always;
+                    add_header 'Access-Control-Allow-Headers' '*' always;
+                    add_header 'Access-Control-Max-Age' '1728000' always;
+
+                    add_header 'Content-Type'  'text/plain charset=UTF-8' always;
+                    add_header 'Content-Length' '0' always;
+                    return 204;
+                }
+
+                proxy_pass http://logfire-ff-ingest-api:8012;
+            }
+
+            # Proxy all other requests to logfire-backend
+            location / {
+
+                if ($request_method = 'OPTIONS') {
+                    add_header 'Access-Control-Allow-Origin' '{{ include "logfire.frontend" . }}' always;
+                    add_header 'Access-Control-Allow-Credentials' 'true' always;
+                    add_header 'Access-Control-Allow-Methods' '*' always;
+                    add_header 'Access-Control-Allow-Headers' '*' always;
+                    add_header 'Access-Control-Max-Age' '1728000' always;
+
+                    add_header 'Content-Type'  'text/plain charset=UTF-8' always;
+                    add_header 'Content-Length' '0' always;
+                    return 204;
+                }
+
+                proxy_pass http://logfire-backend:8000;
+            }
+
+            # WebSocket headers
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+    
+            # Optional for WebSocket stability
+            proxy_set_header Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+    
+            # Timeout settings
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+
+            client_max_body_size 1024m;
+        }
+
+        server {
+            server_name {{ .Values.ingress.frontendHostname }};
+            listen 80;
+
+            # Proxy all other requests to logfire-backend
+            location / {
+                proxy_pass http://logfire-frontend:3000;
+            }
+
+            # WebSocket headers
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+    
+            # Optional for WebSocket stability
+            proxy_set_header Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+    
+            # Timeout settings
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+spec:
+  replicas: {{ dig "replicas" "1" (index .Values $serviceName | default dict) }}
+  selector:
+    matchLabels:
+      {{- include "logfire.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ $serviceName }}
+  template:
+    metadata:
+      labels:
+        {{- include "logfire.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ $serviceName }}
+    spec:
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . | quote }}
+      {{- end }}
+      {{- end }}
+      {{- with (index .Values $serviceName | default dict).initContainers }}
+      initContainers:
+        {{- . | toYaml | nindent 8 }}
+      {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: nginx:1.27.4
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx
+          ports:
+            - containerPort: 80
+          {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
+          env:
+            - name: PUBLIC_API_HOST
+              value: {{ .Values.ingress.apiHostname }}
+            - name: STRIPE_PUBLISHABLE_KEY
+              value: ""
+            - name: IMAGE_TAG
+              value: local
+            - name: POSTHOG_API_KEY
+              value: ""
+            - name: POSTHOG_API_HOST
+              value: ""
+            - name: OTEL_SERVICE_NAME
+              value: {{ $serviceName }}
+            {{ if eq (.Values.ingress.tls | default false) false }}
+            - name: E2E
+              value: "true"
+            {{ end }}
+            {{- with (index .Values $serviceName | default dict).env }}
+              {{- . | toYaml | nindent 12 }}
+            {{- end}}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+{{- template "logfire.hpa" (dict "Values" .Values "serviceName" $serviceName) }}

--- a/chart/templates/logfire-worker.yaml
+++ b/chart/templates/logfire-worker.yaml
@@ -33,8 +33,12 @@ spec:
       initContainers:
         {{- . | toYaml | nindent 8 }}
       {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: worker
+        - name: {{ $serviceName }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.workerImage }}:{{ .Values.image.tag }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
@@ -73,7 +77,7 @@ spec:
             - name: COLLECTOR_OTLP_GRPC_HOST
               value: http://logfire-otel-collector:4317
             - name: FRONTEND_HOST
-              value: {{ include "logfire.frontend" . }}
+              value: {{ include "logfire.frontend" . | quote }}
             - name: USAGE_TO_BUCKET_BUCKET_NAME
               value: {{ .Values.usageObjectStoreUri }}/usage
             {{ if .Values.dev.deployMaildev }}

--- a/chart/values.k3s.yaml
+++ b/chart/values.k3s.yaml
@@ -27,12 +27,7 @@ ingress:
   ingressClassName: nginx
   annotations:
     cert-manager.io/cluster-issuer: k3s-ca-issuer
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://logfire.k3s.local"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Logfire-Context"
-    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+
 
 logfire-frontend:
   env: 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,13 +2,14 @@
 imagePullSecrets: []
 
 ingress:
-  # -- Enable Ingress Resource
+  # -- Enable Ingress Resource.  
+  # If you're not using an ingress resource, for CORS you still need to configure `tls`, `apiHostname` & `frontendHostname`
   enabled: false
-  # -- Enable TLS Certificates
-  tls: 
-  # -- The hostname used for the API endpoint
+  # -- Enable TLS/HTTPS connections.  Required for CORS headers
+  tls: false
+  # -- The hostname used for the API endpoint.  Required for CORS headers
   apiHostname: 
-  # -- The hostname used for the frontend endpoint
+  # -- The hostname used for the frontend endpoint. Required for CORS headers
   frontendHostname: 
   # -- The kind of ingress controller to use i.e, `nginx`
   ingressClassName: nginx
@@ -149,6 +150,21 @@ objectStore:
 
 # -- the Kubernetes Service Account that is used by the pods
 serviceAccountName: default
+
+# -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
 image:
   # -- The pull policy for docker images


### PR DESCRIPTION
This adjusts the helm chart by:

* Adding a new service, `logfire-service` which acts as a single API/frontend endpoint to send traffic to.  **Note**: you still need to configure `tls`, `apiHostname` & `frontendHostname` under `ingress` for this to set appropriate CORS headers (but still set `ingress.enabled` to `false` if you're not using ingress controllers)
* Adds `podSecurityContext` & `securityContext` for setting security context for all the pods.