### PR TITLE
Add the new ipc env var in preparation for split

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.13
+version: 0.1.14
 name: logfire
 description: Helm chart for self-hosted Logfire
 

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -11,6 +11,7 @@ data:
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
   FF_USAGE_REDIS_DSN: {{ .Values.redisDsn }}
   FF_CACHE_OBJECT_STORE_URI: "http://logfire-ff-conhash-cache:9001"
+  FF_IPC_CACHE_URI: "http://logfire-ff-conhash-cache:9001"
   FF_CACHE_ARROW_IPC_CHANCE: "1.0"
   FF_BACKEND_SERVICE_URL: "http://logfire-backend:8000"
   FF_AUTH_TOKEN_REDIS_DSN: {{ .Values.redisDsn }}


### PR DESCRIPTION
This adds the new env var to work with the new split cache.  It doesn't break out the cache deployment yet though, just means it will work with newer logfire versions