### PR TITLE
Show app version on frontend

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-version: 0.1.28
+version: 0.1.29
 name: logfire
 description: Helm chart for self-hosted Logfire
 
-appVersion: "8fea70ea"
+appVersion: "5f5266e0"
 
 dependencies: []

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -18,5 +18,5 @@ data:
   RUST_LOG: "info"
   RUST_BACKTRACE: "full"
   FF_SEND_TO_LOGFIRE: "true"
-  FF_CONSOLE_MODE: "force"
+  FF_FORCE_CONSOLE_LOGGING: "true"
   OTEL_RESOURCE_ATTRIBUTES: "vcs.repository.url.full=https://github.com/pydantic/platform,vcs.repository.ref.revision=main,logfire.code.work_dir=/app"

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -64,7 +64,11 @@ spec:
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           command:
             - fusionfire
+            {{- if (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
             - query
+            {{- else }}
+            - query-worker
+            {{- end }}
             - --host=0.0.0.0
             - --port=8011
           ports:

--- a/charts/logfire/templates/logfire-service-config.yaml
+++ b/charts/logfire/templates/logfire-service-config.yaml
@@ -13,6 +13,7 @@ data:
       regions: [{"name": "local", "frontend_host": "{{ include "logfire.url" . }}", "api_host": "{{ include "logfire.url" . }}", "auth_host": "{{ include "logfire.url" . }}"}],
       dexPublicUrl: '{{ include "logfire.url" . }}',
       dexDynamicRedirect: {{ .Values.dexDynamicRedirect | default false }},
+      appVersion: '{{ .Chart.AppVersion }}',
       selfHosted: true
     }
 ---
@@ -32,13 +33,13 @@ data:
     # from nginx unprivileged: https://github.com/nginxinc/docker-nginx-unprivileged/blob/3dd602719a37ff9b6095c44d4fd7f35b3c07b012/Dockerfile-debian.template#L129-L132
     pid /tmp/nginx.pid;
     daemon off;
-    
+
     events {
         multi_accept        on;
         worker_connections  1024;
         use                 epoll;
     }
-    
+
     http {
         # from nginx unprivileged: https://github.com/nginxinc/docker-nginx-unprivileged/blob/3dd602719a37ff9b6095c44d4fd7f35b3c07b012/Dockerfile-debian.template#L129-L132
         proxy_temp_path /tmp/proxy_temp;
@@ -157,11 +158,11 @@ data:
                 add_header Cache-Control "public, max-age=2592000";
                 add_header Access-Control-Allow-Origin "{{ include "logfire.url" . }}";
             }
-        
+
             # custom panels iframe
             location /custom-components-iframe.html {
                 try_files /custom-components-iframe.html =404;
-        
+
                 add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload;" always;
                 add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src *; worker-src 'self' blob:; trusted-types default logfirePolicy allow-duplicates tokenizeToString standaloneColorizer editorViewLayer domLineBreaksComputer diffReview  diffEditorWidget  editorGhostText stickyScrollViewLayer defaultWorkerFactory LanguageTool_Executor_Policy; font-src 'self'; object-src 'self' blob:; frame-src 'self'; img-src *; base-uri 'self'; form-action 'self'; manifest-src 'self'; frame-ancestors 'self';" always;
             }


### PR DESCRIPTION
This updates the helm chart to support our latest version of logfire, which has the ability to show the app version on the frontend (in the user side panel):

![image](https://github.com/user-attachments/assets/33ab75da-abf7-4677-abe6-2ec29a2d8432)

