### PR TITLE
Release 0.13.9 - Fix/worker ai provider env 

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.8
+version: 0.13.9
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.8](https://img.shields.io/badge/Version-0.13.8-informational?style=flat-square) ![AppVersion: db7bde1d](https://img.shields.io/badge/AppVersion-db7bde1d-informational?style=flat-square)
+![Version: 0.13.9](https://img.shields.io/badge/Version-0.13.9-informational?style=flat-square) ![AppVersion: db7bde1d](https://img.shields.io/badge/AppVersion-db7bde1d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -20,6 +20,11 @@ objectStore:
     AWS_ENDPOINT: http://logfire-minio:9000
     AWS_ALLOW_HTTP: "true"
 
+ai:
+  model: openai:gpt-4o
+  openAi:
+    apiKey: dummy
+
 dev:
   deployPostgres: true
   deployMinio: true

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -465,6 +465,61 @@ Usage: {{ include "logfire.renderOtelResourceAttributes" (dict "service.name" "m
 {{- end -}}
 
 {{/*
+Render shared AI provider environment variables for workloads that construct AI clients.
+*/}}
+{{- define "logfire.aiProviderEnv" -}}
+{{- with .Values.ai.openAi }}
+{{- with .apiKey }}
+- name: OPENAI_API_KEY
+  {{- if kindIs "map" . }}
+  {{- if hasKey . "valueFrom" }}
+  valueFrom:
+    {{- toYaml .valueFrom | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  value: {{ . }}
+  {{- end }}
+{{- end }}
+{{- with .baseUrl }}
+- name: OPENAI_BASE_URL
+  {{- if kindIs "map" . }}
+  {{- if hasKey . "valueFrom" }}
+  valueFrom:
+    {{- toYaml .valueFrom | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  value: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- with .Values.ai.vertexAi.region }}
+- name: GOOGLE_CLOUD_LOCATION
+  value: {{ . }}
+{{- end }}
+{{- with .Values.ai.azureOpenAi }}
+{{- with .endpoint }}
+- name: AZURE_OPENAI_ENDPOINT
+  value: {{ . }}
+{{- end }}
+{{- with .apiKey }}
+- name: AZURE_OPENAI_API_KEY
+  {{- if kindIs "map" . }}
+  {{- if hasKey . "valueFrom" }}
+  valueFrom:
+    {{- toYaml .valueFrom | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  value: {{ . }}
+  {{- end }}
+{{- end }}
+{{- with .apiVersion }}
+- name: OPENAI_API_VERSION
+  value: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create dex config secret name
 */}}
 {{- define "logfire.dexSecretName" -}}

--- a/charts/logfire/templates/logfire-backend.yaml
+++ b/charts/logfire/templates/logfire-backend.yaml
@@ -144,55 +144,7 @@ spec:
             - name: AI_MODEL_CHAT
               value: {{ . }}
             {{- end }}
-            {{- with .openAi }}
-            {{- with .apiKey }}
-            - name: OPENAI_API_KEY
-              {{- if kindIs "map" . }}
-              {{- if hasKey . "valueFrom" }}
-              valueFrom:
-                {{- toYaml .valueFrom | nindent 16 }}
-              {{- end }}
-              {{- else }}
-              value: {{ . }}
-              {{- end }}
-            {{- end }}
-            {{- with .baseUrl }}
-            - name: OPENAI_BASE_URL
-              {{- if kindIs "map" . }}
-              {{- if hasKey . "valueFrom" }}
-              valueFrom:
-                {{- toYaml .valueFrom | nindent 16 }}
-              {{- end }}
-              {{- else }}
-              value: {{ . }}
-              {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- with .vertexAi.region }}
-            - name: GOOGLE_CLOUD_LOCATION
-              value: {{ . }}
-            {{- end }}
-            {{- with .azureOpenAi }}
-            {{- with .endpoint}}
-            - name: AZURE_OPENAI_ENDPOINT
-              value: {{ . }}
-            {{- end }}
-            {{- with .apiKey}}
-            - name: AZURE_OPENAI_API_KEY
-              {{- if kindIs "map" . }}
-              {{- if hasKey . "valueFrom" }}
-              valueFrom:
-                {{- toYaml .valueFrom | nindent 16 }}
-              {{- end }}
-              {{- else }}
-              value: {{ . }}
-              {{- end }}
-            {{- end }}
-            {{- with .apiVersion}}
-            - name: OPENAI_API_VERSION
-              value: {{ . }}
-            {{- end }}
-            {{- end }}
+            {{ include "logfire.aiProviderEnv" $ | nindent 12 }}
             {{- with .enterpriseModel }}
             - name: AI_ENTERPRISE_MODEL_DEFAULT
               value: {{ . }}

--- a/charts/logfire/templates/logfire-worker.yaml
+++ b/charts/logfire/templates/logfire-worker.yaml
@@ -108,9 +108,12 @@ spec:
               value: http://logfire-otel-collector:4317
             - name: FRONTEND_HOST
               value: {{ include "logfire.url" . | quote }}
-            {{- with .Values.ai.model }}
+            {{- with .Values.ai }}
+            {{- with .model }}
             - name: AI_MODEL_DEFAULT
               value: {{ . }}
+            {{- end }}
+            {{ include "logfire.aiProviderEnv" $ | nindent 12 }}
             {{- end }}
             - name: USAGE_TO_BUCKET_BUCKET_NAME
               value: {{ .Values.objectStore.uri }}/usage


### PR DESCRIPTION
## Summary
Fix `logfire-worker` startup when `ai.model` is configured by propagating the same AI provider environment variables as the backend.

## Upgrade notes
No action is required.
If you worked around the `0.13.8` regression by setting `ai.model: ""`, you can remove it after upgrading to `0.13.9` and restore your normal `ai` settings.
