### PR TITLE
Tune ingest concurrency

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.11
+version: 0.13.12
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -680,7 +680,7 @@ Before diving deeper, verify these common configuration issues:
 | logfire-dex.service.annotations | object | `{}` | Service annotations |
 | logfire-ff-cache-byte | object | `{"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
 | logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume |
-| logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"64Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
+| logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"16Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
 | logfire-ff-ingest-processor | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}}}` | Autoscaling & resources for the `logfire-ff-ingest-processor` pod |
 | logfire-ff-ingest-processor.annotations | object | `{}` | Workload annotations |
 | logfire-ff-ingest-processor.env | list | `[{"name":"RUST_LOG","value":"warn"}]` | Extra env vars for the ingest processor pod |
@@ -694,8 +694,8 @@ Before diving deeper, verify these common configuration issues:
 | logfire-ff-ingest.podAnnotations | object | `{}` | Pod annotations |
 | logfire-ff-ingest.podLabels | object | `{}` | Pod labels |
 | logfire-ff-ingest.service.annotations | object | `{}` | Service annotations |
-| logfire-ff-ingest.volumeClaimTemplates | object | `{"storage":"64Gi"}` | Configuration for the StatefulSet PersistentVolumeClaim template |
-| logfire-ff-ingest.volumeClaimTemplates.storage | string | `"64Gi"` | Storage provisioned for each pod |
+| logfire-ff-ingest.volumeClaimTemplates | object | `{"storage":"16Gi"}` | Configuration for the StatefulSet PersistentVolumeClaim template |
+| logfire-ff-ingest.volumeClaimTemplates.storage | string | `"16Gi"` | Storage provisioned for each pod |
 | logfire-ff-maintenance-scheduler | object | `{"env":[{"name":"RUST_LOG","value":"warn"}]}` | Environment overrides for the maintenance scheduler pod |
 | logfire-ff-query-api | object | `{"env":[{"name":"RUST_LOG","value":"warn"}]}` | Environment overrides for the query API pod |
 | logfire-redis.enabled | bool | `true` | Deploy Redis as part of this chart. Disable to use an external Redis instance. |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.11](https://img.shields.io/badge/Version-0.13.11-informational?style=flat-square) ![AppVersion: 7a510972](https://img.shields.io/badge/AppVersion-7a510972-informational?style=flat-square)
+![Version: 0.13.12](https://img.shields.io/badge/Version-0.13.12-informational?style=flat-square) ![AppVersion: 7a510972](https://img.shields.io/badge/AppVersion-7a510972-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -680,7 +680,7 @@ Before diving deeper, verify these common configuration issues:
 | logfire-dex.service.annotations | object | `{}` | Service annotations |
 | logfire-ff-cache-byte | object | `{"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
 | logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume |
-| logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"16Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
+| logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"64Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
 | logfire-ff-ingest-processor | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}}}` | Autoscaling & resources for the `logfire-ff-ingest-processor` pod |
 | logfire-ff-ingest-processor.annotations | object | `{}` | Workload annotations |
 | logfire-ff-ingest-processor.env | list | `[{"name":"RUST_LOG","value":"warn"}]` | Extra env vars for the ingest processor pod |
@@ -694,8 +694,8 @@ Before diving deeper, verify these common configuration issues:
 | logfire-ff-ingest.podAnnotations | object | `{}` | Pod annotations |
 | logfire-ff-ingest.podLabels | object | `{}` | Pod labels |
 | logfire-ff-ingest.service.annotations | object | `{}` | Service annotations |
-| logfire-ff-ingest.volumeClaimTemplates | object | `{"storage":"16Gi"}` | Configuration for the StatefulSet PersistentVolumeClaim template |
-| logfire-ff-ingest.volumeClaimTemplates.storage | string | `"16Gi"` | Storage provisioned for each pod |
+| logfire-ff-ingest.volumeClaimTemplates | object | `{"storage":"64Gi"}` | Configuration for the StatefulSet PersistentVolumeClaim template |
+| logfire-ff-ingest.volumeClaimTemplates.storage | string | `"64Gi"` | Storage provisioned for each pod |
 | logfire-ff-maintenance-scheduler | object | `{"env":[{"name":"RUST_LOG","value":"warn"}]}` | Environment overrides for the maintenance scheduler pod |
 | logfire-ff-query-api | object | `{"env":[{"name":"RUST_LOG","value":"warn"}]}` | Environment overrides for the query API pod |
 | logfire-redis.enabled | bool | `true` | Deploy Redis as part of this chart. Disable to use an external Redis instance. |

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -45,6 +45,37 @@ Resolve query parallelism from explicit service values, falling back to the comp
 {{- end -}}
 
 {{/*
+Default ingest direct-file buffering.
+Keeps the in-memory direct-file submit buffer to roughly 1/8 of the pod memory
+request and caps concurrency at the platform value used by larger ingest pods.
+*/}}
+{{- define "logfire.ffIngestDirectFileSettingsDefault" -}}
+{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
+{{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
+{{- $memory := get $effectiveResources "memoryRequest" -}}
+{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
+{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
+{{- $bufferMi := min 8 (max 1 (div $memoryMi 256)) -}}
+{{- $memoryBudgetMi := max $bufferMi (div $memoryMi 8) -}}
+{{- $memoryConcurrency := max 1 (div $memoryBudgetMi $bufferMi) -}}
+{{- $cpuConcurrency := mul $cpuCores 32 -}}
+{{- $submitConcurrency := min 128 (max 1 (min $cpuConcurrency $memoryConcurrency)) -}}
+{{- dict "bufferMaxBytes" (printf "%dMB" $bufferMi) "submitConcurrency" $submitConcurrency | toJson -}}
+{{- end -}}
+
+{{/*
+Resolve ingest direct-file buffering from explicit service values, falling back
+to computed defaults.
+*/}}
+{{- define "logfire.ffIngestDirectFileSettings" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- $defaults := include "logfire.ffIngestDirectFileSettingsDefault" . | fromJson -}}
+{{- $bufferMaxBytes := get $effectiveServiceValues "directFileBufferMaxBytes" | default (get $defaults "bufferMaxBytes") -}}
+{{- $submitConcurrency := get $effectiveServiceValues "directFileSubmitConcurrency" | default (get $defaults "submitConcurrency") -}}
+{{- dict "bufferMaxBytes" $bufferMaxBytes "submitConcurrency" $submitConcurrency | toJson -}}
+{{- end -}}
+
+{{/*
 Resolve query-api parallelism. When dedicated query-workers are enabled,
 default from query-worker sizing because query-api schedules work onto workers.
 */}}

--- a/charts/logfire/templates/logfire-ff-ingest-processor.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest-processor.yaml
@@ -103,12 +103,6 @@ spec:
             - name: OTEL_TRACES_SAMPLER
               value: "parentbased_traceidratio"
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
-            - name: FF_INGEST_PATH
-              value: "/tmp/ingest-data"
-            - name: FF_INGEST_NUM_WORKERS
-              value: "0"
-            - name: FF_INGEST_NUM_CLEANUP_WORKERS
-              value: "0"
             - name: FF_IO_THREADS
               value: {{ $cpuCores | quote }}
             - name: FF_DATAFUSION_THREADS

--- a/charts/logfire/templates/logfire-ff-ingest-processor.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest-processor.yaml
@@ -109,10 +109,6 @@ spec:
               value: "0"
             - name: FF_INGEST_NUM_CLEANUP_WORKERS
               value: "0"
-            - name: FF_DIRECT_FILE_INGEST_SUBMIT_CONCURRENCY
-              value: "128"
-            - name: FF_INGEST_DIRECT_FILE_BUFFER_MAX_BYTES
-              value: "8MB"
             - name: FF_IO_THREADS
               value: {{ $cpuCores | quote }}
             - name: FF_DATAFUSION_THREADS

--- a/charts/logfire/templates/logfire-ff-ingest.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest.yaml
@@ -108,6 +108,10 @@ spec:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: FF_INGEST_PATH
               value: "/fusionfire/ingest-data"
+            - name: FF_DIRECT_FILE_INGEST_SUBMIT_CONCURRENCY
+              value: "32"
+            - name: FF_INGEST_DIRECT_FILE_BUFFER_MAX_BYTES
+              value: "8MB"
             - name: FF_INGEST_NUM_WORKERS
               value: {{ mul $cpuCores 8 | quote }}
             - name: FF_INGEST_DOWNSTREAM_URL

--- a/charts/logfire/templates/logfire-ff-ingest.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest.yaml
@@ -2,6 +2,7 @@
 {{- $serviceValues := get .Values $serviceName | default dict -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $directFileSettings := include "logfire.ffIngestDirectFileSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $cpuCores := int (get $threadSettings "cpuCores") -}}
 {{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
 
@@ -108,14 +109,12 @@ spec:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: FF_INGEST_PATH
               value: "/fusionfire/ingest-data"
-            - name: FF_DIRECT_FILE_INGEST_SUBMIT_CONCURRENCY
-              value: "32"
-            - name: FF_INGEST_DIRECT_FILE_BUFFER_MAX_BYTES
-              value: "8MB"
-            - name: FF_INGEST_NUM_WORKERS
-              value: {{ mul $cpuCores 8 | quote }}
             - name: FF_INGEST_DOWNSTREAM_URL
               value: "{{ include "logfire.scheme" . }}://logfire-ff-ingest-processor:{{ include "logfire.port" (dict "port" 8012 "root" .) }}"
+            - name: FF_INGEST_DIRECT_FILE_BUFFER_MAX_BYTES
+              value: {{ get $directFileSettings "bufferMaxBytes" | quote }}
+            - name: FF_DIRECT_FILE_INGEST_SUBMIT_CONCURRENCY
+              value: {{ get $directFileSettings "submitConcurrency" | quote }}
             - name: FF_IO_THREADS
               value: {{ $cpuCores | quote }}
             - name: FF_DATAFUSION_THREADS

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -467,7 +467,7 @@ logfire-ff-ingest:
   # -- Configuration for the StatefulSet PersistentVolumeClaim template
   volumeClaimTemplates:
     # -- Storage provisioned for each pod
-    storage: 64Gi
+    storage: 16Gi
 
   # -- Extra env vars for the ingest pod
   env:
@@ -1605,7 +1605,7 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-ingest:
       volumeClaimTemplates:
-        storage: 64Gi
+        storage: 16Gi
       resources:
         cpu: "1"
         memory: "2Gi"

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -467,7 +467,7 @@ logfire-ff-ingest:
   # -- Configuration for the StatefulSet PersistentVolumeClaim template
   volumeClaimTemplates:
     # -- Storage provisioned for each pod
-    storage: 16Gi
+    storage: 64Gi
 
   # -- Extra env vars for the ingest pod
   env:
@@ -476,6 +476,11 @@ logfire-ff-ingest:
 
   # //// Enables serviceName for older K8s versions
   # serviceName: true
+
+  # -- Direct-file ingest buffer size per submit worker. Defaults from pod memory request, capped at 8MB.
+  # directFileBufferMaxBytes: "8MB"
+  # -- Direct-file ingest submit concurrency. Defaults from CPU and memory request, capped at 128.
+  # directFileSubmitConcurrency: 32
 
   # resources:
   #   cpu: "1"
@@ -1600,7 +1605,7 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-ingest:
       volumeClaimTemplates:
-        storage: 16Gi
+        storage: 64Gi
       resources:
         cpu: "1"
         memory: "2Gi"


### PR DESCRIPTION
## Summary

Aligns with ingest measurements as per the devops channel. 

This changes the limits applied to the ingest pod so that it aligns more with the `standard` sizing preset of 1 cpu & 2gb RAM for the ingest pod.

## Upgrade notes

### Breaking changes

