### PR TITLE
Small sizing preset

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     permissions:
       id-token: write
       contents: read

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.14
+version: 0.13.15
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.14](https://img.shields.io/badge/Version-0.13.14-informational?style=flat-square) ![AppVersion: a013748c](https://img.shields.io/badge/AppVersion-a013748c-informational?style=flat-square)
+![Version: 0.13.15](https://img.shields.io/badge/Version-0.13.15-informational?style=flat-square) ![AppVersion: a013748c](https://img.shields.io/badge/AppVersion-a013748c-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -514,7 +514,7 @@ logfire.info('Hello, {place}!', place='World')
 
 Logfire is designed to be horizontally scalable. You can adjust the replica counts and resources for each component to handle your specific workload.
 
-For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments. For a very low-traffic instance, `sizingPreset: small` provides a smaller footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
+For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments, `sizingPreset: small` for lower-traffic deployments that still need room for ingest/query spikes, or `sizingPreset: tiny` for a very low-traffic instance with the smallest footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
 
 `sizingPreset` only covers workload sizing. You still need to configure environment-specific prerequisites such as hostnames/TLS, image pull secrets, PostgreSQL, object storage URI and credentials, and any required `storageClassName` values if your cluster has no suitable default StorageClass.
 
@@ -765,7 +765,7 @@ Before diving deeper, verify these common configuration issues:
 | serviceAccount.create | bool | `false` | Create a ServiceAccount |
 | serviceAccount.name | string | `""` | Name of the ServiceAccount. If not set and create is true, a name is generated using the fullname template. If create is false and this is not set, the default ServiceAccount is used. |
 | serviceAccountName | string | `"default"` | DEPRECATED: Use serviceAccount.name instead. Kept for backward compatibility. @deprecated |
-| sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` or `small` to apply built-in customer sizing defaults. |
+| sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `standard`, `small`, or `tiny` to apply built-in customer sizing defaults. |
 | smtp.host | string | `nil` | SMTP server hostname |
 | smtp.password | string | `nil` | SMTP password. Can be a plain string or a map with valueFrom (e.g., secretKeyRef). |
 | smtp.port | int | `25` | SMTP server port |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -514,7 +514,7 @@ logfire.info('Hello, {place}!', place='World')
 
 Logfire is designed to be horizontally scalable. You can adjust the replica counts and resources for each component to handle your specific workload.
 
-For customer deployments, we recommend starting with `sizingPreset: standard`. This applies the built-in workload resources, autoscaling, PDBs, and scratch/ingest volume sizes from `values.yaml`; you can still override any individual workload after selecting the preset.
+For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments. For a very low-traffic instance, `sizingPreset: small` provides a smaller footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
 
 `sizingPreset` only covers workload sizing. You still need to configure environment-specific prerequisites such as hostnames/TLS, image pull secrets, PostgreSQL, object storage URI and credentials, and any required `storageClassName` values if your cluster has no suitable default StorageClass.
 
@@ -762,7 +762,7 @@ Before diving deeper, verify these common configuration issues:
 | serviceAccount.create | bool | `false` | Create a ServiceAccount |
 | serviceAccount.name | string | `""` | Name of the ServiceAccount. If not set and create is true, a name is generated using the fullname template. If create is false and this is not set, the default ServiceAccount is used. |
 | serviceAccountName | string | `"default"` | DEPRECATED: Use serviceAccount.name instead. Kept for backward compatibility. @deprecated |
-| sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` to apply the built-in customer sizing defaults. |
+| sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` or `small` to apply built-in customer sizing defaults. |
 | smtp.host | string | `nil` | SMTP server hostname |
 | smtp.password | string | `nil` | SMTP password. Can be a plain string or a map with valueFrom (e.g., secretKeyRef). |
 | smtp.port | int | `25` | SMTP server port |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -525,6 +525,7 @@ logfire-worker:
   resources:
     cpu: "500m"
     memory: "1Gi"
+    ephemeralStorage: "1Gi"
 ```
 
 This is how you can configure each service:
@@ -538,9 +539,11 @@ This is how you can configure each service:
     requests:
       cpu: "500m"
       memory: "1Gi"
+      ephemeral-storage: "1Gi"
     limits:
       cpu: "1"
       memory: "2Gi"
+      ephemeral-storage: "2Gi"
   # -- Autoscaler settings
   autoscaling:
     minReplicas: 2

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -515,7 +515,7 @@ logfire.info('Hello, {place}!', place='World')
 
 Logfire is designed to be horizontally scalable. You can adjust the replica counts and resources for each component to handle your specific workload.
 
-For customer deployments, we recommend starting with `sizingPreset: standard`. This applies the built-in workload resources, autoscaling, PDBs, and scratch/ingest volume sizes from `values.yaml`; you can still override any individual workload after selecting the preset.
+For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments. For a very low-traffic instance, `sizingPreset: small` provides a smaller footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
 
 `sizingPreset` only covers workload sizing. You still need to configure environment-specific prerequisites such as hostnames/TLS, image pull secrets, PostgreSQL, object storage URI and credentials, and any required `storageClassName` values if your cluster has no suitable default StorageClass.
 

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -515,7 +515,7 @@ logfire.info('Hello, {place}!', place='World')
 
 Logfire is designed to be horizontally scalable. You can adjust the replica counts and resources for each component to handle your specific workload.
 
-For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments. For a very low-traffic instance, `sizingPreset: small` provides a smaller footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
+For customer deployments, we recommend starting with a built-in sizing preset. Use `sizingPreset: standard` for general production deployments, `sizingPreset: small` for lower-traffic deployments that still need room for ingest/query spikes, or `sizingPreset: tiny` for a very low-traffic instance with the smallest footprint. Presets apply workload resources, autoscaling, PDBs, and selected FusionFire execution settings; you can still override any individual workload after selecting the preset.
 
 `sizingPreset` only covers workload sizing. You still need to configure environment-specific prerequisites such as hostnames/TLS, image pull secrets, PostgreSQL, object storage URI and credentials, and any required `storageClassName` values if your cluster has no suitable default StorageClass.
 

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -526,6 +526,7 @@ logfire-worker:
   resources:
     cpu: "500m"
     memory: "1Gi"
+    ephemeralStorage: "1Gi"
 ```
 
 This is how you can configure each service:
@@ -539,9 +540,11 @@ This is how you can configure each service:
     requests:
       cpu: "500m"
       memory: "1Gi"
+      ephemeral-storage: "1Gi"
     limits:
       cpu: "1"
       memory: "2Gi"
+      ephemeral-storage: "2Gi"
   # -- Autoscaler settings
   autoscaling:
     minReplicas: 2

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -1,5 +1,5 @@
 adminEmail: hello@example.dev
-sizingPreset: dev
+sizingPreset: small
 
 # -- test with security context
 podSecurityContext:
@@ -70,6 +70,11 @@ logfire-ff-maintenance-worker:
 
 logfire-ff-ingest:
   volumeClaimTemplates:
+    storageClassName: standard
+    storage: "1Gi"
+
+logfire-ff-cache-byte:
+  scratchVolume:
     storageClassName: standard
     storage: "1Gi"
 

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -1,5 +1,5 @@
 adminEmail: hello@example.dev
-sizingPreset: small
+sizingPreset: tiny
 
 # -- test with security context
 podSecurityContext:

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -182,6 +182,8 @@ small pods conservative while allowing larger workers to make progress.
 Default background maintenance/compaction object-store download concurrency.
 Sub-core workers keep download concurrency low to avoid memory spikes, but
 workers with more than 1Gi memory can tolerate a second in-flight download.
+Full-core workers with less than 8Gi memory use moderate download concurrency;
+larger workers keep the historical platform default.
 */}}
 {{- define "logfire.ffBackgroundDownloadParallelismDefault" -}}
 {{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
@@ -195,6 +197,8 @@ workers with more than 1Gi memory can tolerate a second in-flight download.
 {{- else -}}
 1
 {{- end -}}
+{{- else if lt $memoryMi 8192 -}}
+4
 {{- else -}}
 10
 {{- end -}}

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -15,6 +15,27 @@ Helpers specific to Fusionfire workloads and configuration.
 {{- end -}}
 {{- end -}}
 
+{{- define "logfire.ffMaxCompactionJobSizeBytesDefault" -}}
+{{- $compactionWorker := dict "Values" .Values "serviceName" "logfire-ff-compaction-worker" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" $compactionWorker | fromJson -}}
+{{- $resources := get $effectiveServiceValues "resources" | default dict -}}
+{{- if $resources -}}
+{{- $effectiveResources := include "logfire.effectiveResources" $compactionWorker | fromJson -}}
+{{- $memory := get $effectiveResources "memoryRequest" -}}
+{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
+{{- $jobSizeMi := min 512 (max 32 (div $memoryMi 16)) -}}
+{{- printf "%dMB" $jobSizeMi -}}
+{{- else -}}
+512MB
+{{- end -}}
+{{- end -}}
+
+{{- define "logfire.ffMaxCompactionJobSizeBytes" -}}
+{{- $maintenanceServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-maintenance-worker") | fromJson -}}
+{{- $compactionServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-compaction-worker") | fromJson -}}
+{{- coalesce (get $compactionServiceValues "maxCompactionJobSizeBytes") (get $maintenanceServiceValues "maxCompactionJobSizeBytes") (include "logfire.ffMaxCompactionJobSizeBytesDefault" .) -}}
+{{- end -}}
+
 {{/*
 Derive FF service CPU core count and DataFusion thread count from the effective CPU request.
 */}}
@@ -97,19 +118,45 @@ Uses half the pod memory request, leaving headroom for the HTTP process/runtime.
 {{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
 {{- $memory := get $effectiveResources "memoryRequest" -}}
 {{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
-{{- $datafusionMemoryMi := max 512 (div $memoryMi 2) -}}
+{{- $datafusionMemoryMi := max 256 (div $memoryMi 2) -}}
 {{- printf "%dMB" $datafusionMemoryMi -}}
 {{- end -}}
 
 {{/*
 Default DataFusion memory cap for background maintenance/compaction workers.
-Uses the pod memory limit so burstable workers can use their configured headroom.
+Larger workers use the pod memory limit so burstable workers can use their
+configured headroom. Sub-core workers use a smaller fraction to leave room for
+the process runtime, object store clients, decompression, and parquet writers.
 */}}
 {{- define "logfire.ffBackgroundDatafusionMemoryDefault" -}}
 {{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
+{{- $cpu := get $effectiveResources "cpuRequest" -}}
 {{- $memory := get $effectiveResources "memoryLimit" -}}
+{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
 {{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
-{{- $datafusionMemoryMi := max 512 (div (mul $memoryMi 3) 8) -}}
+{{- $datafusionMemoryMi := 0 -}}
+{{- if lt $cpuMilli 1000 -}}
+  {{- if le $memoryMi 1024 -}}
+    {{- $datafusionMemoryMi = max 128 (div $memoryMi 2) -}}
+  {{- else -}}
+    {{- $datafusionMemoryMi = max 256 (div $memoryMi 8) -}}
+  {{- end -}}
+{{- else -}}
+{{- $datafusionMemoryMi = max 512 (div (mul $memoryMi 3) 8) -}}
+{{- end -}}
+{{- printf "%dMB" $datafusionMemoryMi -}}
+{{- end -}}
+
+{{/*
+Default DataFusion memory cap for the maintenance scheduler.
+The scheduler scans metadata rather than running compaction jobs, so it follows
+the pod memory request directly with a cap matching the previous chart default.
+*/}}
+{{- define "logfire.ffMaintenanceSchedulerDatafusionMemoryDefault" -}}
+{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
+{{- $memory := get $effectiveResources "memoryRequest" -}}
+{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
+{{- $datafusionMemoryMi := min 512 (max 128 $memoryMi) -}}
 {{- printf "%dMB" $datafusionMemoryMi -}}
 {{- end -}}
 
@@ -119,9 +166,38 @@ The runner gates CPU-heavy work to roughly half this value, so cpu+1 keeps
 small pods conservative while allowing larger workers to make progress.
 */}}
 {{- define "logfire.ffBackgroundJobParallelismDefault" -}}
+{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
 {{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
+{{- $cpu := get $effectiveResources "cpuRequest" -}}
+{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
 {{- $cpuCores := int (get $threadSettings "cpuCores") -}}
+{{- if lt $cpuMilli 1000 -}}
+1
+{{- else -}}
 {{- min 10 (max 3 (add $cpuCores 1)) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Default background maintenance/compaction object-store download concurrency.
+Sub-core workers keep download concurrency low to avoid memory spikes, but
+workers with more than 1Gi memory can tolerate a second in-flight download.
+*/}}
+{{- define "logfire.ffBackgroundDownloadParallelismDefault" -}}
+{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
+{{- $cpu := get $effectiveResources "cpuRequest" -}}
+{{- $memory := get $effectiveResources "memoryLimit" -}}
+{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
+{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
+{{- if lt $cpuMilli 1000 -}}
+{{- if gt $memoryMi 1024 -}}
+2
+{{- else -}}
+1
+{{- end -}}
+{{- else -}}
+10
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -142,6 +218,7 @@ Common execution env for background maintenance/compaction workers.
 {{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
 {{- $defaultDatafusionMemory := include "logfire.ffBackgroundDatafusionMemoryDefault" . -}}
 {{- $jobParallelism := include "logfire.ffBackgroundJobParallelism" . -}}
+{{- $downloadParallelism := include "logfire.ffBackgroundDownloadParallelismDefault" . -}}
 {{- $cpuCores := int (get $threadSettings "cpuCores") -}}
 {{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
 - name: FF_IO_THREADS
@@ -159,7 +236,7 @@ Common execution env for background maintenance/compaction workers.
   value: {{ . | quote }}
 {{- end }}
 - name: FF_COMPACTION_DOWNLOAD_PARALLELISM
-  value: {{ (get $effectiveServiceValues "downloadParallelism" | default "10" | quote) }}
+  value: {{ (get $effectiveServiceValues "downloadParallelism" | default $downloadParallelism | quote) }}
 - name: FF_COMPACTION_JOB_PARALLELISM
   value: {{ $jobParallelism | quote }}
 {{- end -}}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -104,7 +104,7 @@ Only sizing-related keys are inherited from presets.
   {{- end -}}
   {{- $presetValues := get $presets $presetName | default dict -}}
   {{- $presetServiceValues := get $presetValues $serviceName | default dict -}}
-  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "queryParallelism" "datafusionMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "downloadParallelism" "jobParallelism" -}}
+  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "queryParallelism" "datafusionMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "downloadParallelism" "jobParallelism" "maxCompactionJobSizeBytes" -}}
     {{- if hasKey $presetServiceValues $key -}}
       {{- $_ := set $merged $key (deepCopy (get $presetServiceValues $key)) -}}
     {{- end -}}

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -66,6 +66,7 @@ data:
   FF_CACHE_OBJECT_STORE_HTTP_HEADERS: x-ff-no-warm-cache=1
   FF_COMPACTION_LOOP_BACKOFF_DELAY: "1s"
   FF_COMPACTION_TIERS: {{ include "logfire.ffCompactionTiersValue" . | squote }}
+  FF_MAX_COMPACTION_JOB_SIZE_BYTES: {{ include "logfire.ffMaxCompactionJobSizeBytes" . | quote }}
   FF_INGEST_MAX_TIME_SKEW: "120s"
 
 ---

--- a/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
@@ -1,6 +1,7 @@
 {{- $serviceName := "logfire-ff-maintenance-scheduler" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $defaultDatafusionMemory := include "logfire.ffMaintenanceSchedulerDatafusionMemoryDefault" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- $cpuCores := int (get $threadSettings "cpuCores") -}}
 {{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
 apiVersion: apps/v1
@@ -86,7 +87,7 @@ spec:
             - name: FF_MAINTENANCE_SCHEDULING_CONCURRENCY
               value: "1"
             - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "512MB" | quote) }}
+              value: {{ (get $effectiveServiceValues "datafusionMemory" | default $defaultDatafusionMemory | quote) }}
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: PG_DSN
               valueFrom:

--- a/charts/logfire/templates/logfire-worker.yaml
+++ b/charts/logfire/templates/logfire-worker.yaml
@@ -66,6 +66,7 @@ spec:
             httpGet:
               path: /health
               port: 8003
+            failureThreshold: 10
           env:
             - name: LOGFIRE_SERVICE_NAME
               value: {{ $serviceName }}

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -51,7 +51,7 @@ rateLimits: {}
 #    perHour: 60
 #    perMinute: 10
 
-# -- Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` or `small` to apply built-in customer sizing defaults.
+# -- Workload sizing preset. Leave empty to skip preset sizing, or set to `standard`, `small`, or `tiny` to apply built-in customer sizing defaults.
 sizingPreset: ""
 
 # ==============================================================================
@@ -1612,7 +1612,7 @@ sizingPresets:
           cpuAverage: 20
       scratchVolume:
         storage: "1Gi"
-  small:
+  tiny:
     logfire-dex:
       resources:
         cpu: "50m"
@@ -1866,6 +1866,270 @@ sizingPresets:
       resources:
         cpu: "150m"
         memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+  small:
+    logfire-dex:
+      resources:
+        cpu: "100m"
+        memory: "128Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-ingest:
+      resources:
+        cpu: "500m"
+        memory: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 12
+        hpa:
+          enabled: true
+          memAverage: 40
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-ingest-processor:
+      resources:
+        cpu: "1"
+        memory: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 12
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-backend:
+      resources:
+        cpu: "750m"
+        memory: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 75
+          cpuAverage: 50
+      pdb:
+        maxUnavailable: 1
+    logfire-remote-mcp:
+      resources:
+        requests:
+          cpu: "150m"
+          memory: "384Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-query-api:
+      queryParallelism: 4
+      resources:
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "2"
+          memory: "3Gi"
+          ephemeral-storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 8
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+      scratchVolume:
+        storage: "2Gi"
+    logfire-ff-query-worker:
+      resources:
+        cpu: "1"
+        memory: "2Gi"
+        ephemeralStorage: "1Gi"
+      scratchVolume:
+        storage: "2Gi"
+    logfire-ff-crud-api:
+      resources:
+        cpu: "125m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-frontend-service:
+      resources:
+        cpu: "100m"
+        memory: "128Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-worker:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 5
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 70
+      pdb:
+        maxUnavailable: 1
+    logfire-ai-gateway:
+      resources:
+        requests:
+          cpu: "150m"
+          memory: "384Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "500m"
+          memory: "768Mi"
+          ephemeral-storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-service:
+      resources:
+        cpu: "500m"
+        memory: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 40
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-cache-byte:
+      resources:
+        cpu: "500m"
+        memory: "1Gi"
+      scratchVolume:
+        storage: "4Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 8
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 25
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-proxy-cache-byte:
+      resources:
+        cpu: "500m"
+        memory: "384Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 8
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 40
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-maintenance-worker:
+      resources:
+        cpu: "500m"
+        memory: "1Gi"
+        ephemeralStorage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 50
+          cpuAverage: 50
+      pdb:
+        maxUnavailable: 1
+      scratchVolume:
+        storage: "2Gi"
+    logfire-ff-maintenance-scheduler:
+      resources:
+        cpu: "250m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 2
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-compaction-worker:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "4Gi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "2"
+          memory: "4Gi"
+          ephemeral-storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 8
+        hpa:
+          enabled: true
+          memAverage: 60
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+      scratchVolume:
+        storage: "2Gi"
+    logfire-otel-collector:
+      resources:
+        cpu: "250m"
+        memory: "512Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1820,7 +1820,7 @@ sizingPresets:
         ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
-        maxReplicas: 1
+        maxReplicas: 3
         hpa:
           enabled: true
           memAverage: 50
@@ -1853,7 +1853,7 @@ sizingPresets:
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
-        maxReplicas: 2
+        maxReplicas: 4
         hpa:
           enabled: true
           memAverage: 70

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -51,7 +51,7 @@ rateLimits: {}
 #    perHour: 60
 #    perMinute: 10
 
-# -- Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` to apply the built-in customer sizing defaults.
+# -- Workload sizing preset. Leave empty to skip preset sizing, or set to `standard` or `small` to apply built-in customer sizing defaults.
 sizingPreset: ""
 
 # ==============================================================================
@@ -736,7 +736,7 @@ aiGatewayOauth:
 #   # -- Parallelism per pod. Defaults to 2x computed FF_IO_THREADS.
 #   # queryParallelism: 4
 #   # -- DataFusion memory limit when query-workers are disabled and query-api runs in query-worker mode.
-#   # Defaults to half of the pod memory request.
+#   # Defaults to half of the pod memory request, with a 256MB floor.
 #   # datafusionMemory: "4096MB"
 #   # -- Number of replicas
 #   replicas: 2
@@ -972,12 +972,18 @@ logfire-ff-cache-byte:
 #   podLabels: {}
 #   # -- Pod annotations
 #   podAnnotations: {}
-#   # -- Compaction job concurrency. Defaults from CPU request, capped at 10.
+#   # -- Compaction job concurrency. Defaults from CPU request: 1 for sub-core workers,
+#   # otherwise CPU cores + 1, bounded between 3 and 10.
 #   # jobParallelism: 3
+#   # -- Compaction object-store download concurrency. Defaults to 1 for sub-core workers, otherwise 10.
 #   downloadParallelism: 10
 #   replicas: 2
-#   # -- DataFusion memory limit. Defaults to 3/8 of the pod memory limit.
+#   # -- DataFusion memory limit. Defaults from CPU and memory resources: sub-core workers
+#   # use conservative memory fractions, larger workers use 3/8 of the pod memory limit.
 #   # datafusionMemory: "3072MB"
+#   # -- Maximum compressed input bytes to schedule into one compaction job.
+#   # Defaults from compaction-worker memory request when sizing is configured, bounded between 32MB and 512MB.
+#   # maxCompactionJobSizeBytes: "512MB"
 #   spillToDiskQuota: "32GB"
 #   compactionTiers:
 #     - size_threshold_bytes: "1KB"
@@ -1033,12 +1039,18 @@ logfire-ff-cache-byte:
 #   podLabels: {}
 #   # -- Pod annotations
 #   podAnnotations: {}
-#   # -- Compaction job concurrency. Defaults from CPU request, capped at 10.
+#   # -- Compaction job concurrency. Defaults from CPU request: 1 for sub-core workers,
+#   # otherwise CPU cores + 1, bounded between 3 and 10.
 #   # jobParallelism: 3
+#   # -- Compaction object-store download concurrency. Defaults to 1 for sub-core workers, otherwise 10.
 #   downloadParallelism: 10
 #   replicas: 2
-#   # -- DataFusion memory limit. Defaults to 3/8 of the pod memory limit.
+#   # -- DataFusion memory limit. Defaults from CPU and memory resources: sub-core workers
+#   # use conservative memory fractions, larger workers use 3/8 of the pod memory limit.
 #   # datafusionMemory: "3072MB"
+#   # -- Maximum compressed input bytes to schedule into one compaction job.
+#   # Defaults from compaction-worker memory request when sizing is configured, bounded between 32MB and 512MB.
+#   # maxCompactionJobSizeBytes: "512MB"
 #   spillToDiskQuota: "32GB"
 #   compactionTiers:
 #     - size_threshold_bytes: "1KB"
@@ -1599,6 +1611,252 @@ sizingPresets:
           cpuAverage: 20
       scratchVolume:
         storage: "1Gi"
+  small:
+    logfire-dex:
+      resources:
+        cpu: "50m"
+        memory: "96Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-ingest:
+      resources:
+        cpu: "250m"
+        memory: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 40
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-ingest-processor:
+      resources:
+        cpu: "350m"
+        memory: "384Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-backend:
+      resources:
+        requests:
+          cpu: "750m"
+          memory: "768Mi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 80
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-remote-mcp:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "384Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-query-api:
+      queryParallelism: 4
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "768Mi"
+        limits:
+          cpu: "1500m"
+          memory: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-crud-api:
+      resources:
+        cpu: "100m"
+        memory: "192Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-frontend-service:
+      resources:
+        cpu: "50m"
+        memory: "96Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-worker:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+        limits:
+          cpu: "1"
+          memory: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 70
+      pdb:
+        maxUnavailable: 1
+    logfire-ai-gateway:
+      resources:
+        cpu: "100m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-service:
+      resources:
+        cpu: "250m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-cache-byte:
+      resources:
+        cpu: "250m"
+        memory: "384Mi"
+      scratchVolume:
+        storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 25
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-proxy-cache-byte:
+      resources:
+        cpu: "150m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 40
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-maintenance-worker:
+      resources:
+        cpu: "250m"
+        memory: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 1
+        hpa:
+          enabled: true
+          memAverage: 50
+          cpuAverage: 50
+      pdb:
+        maxUnavailable: 1
+      scratchVolume:
+        storage: "1Gi"
+    logfire-ff-maintenance-scheduler:
+      resources:
+        cpu: "100m"
+        memory: "192Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 1
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-ff-compaction-worker:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "2Gi"
+        limits:
+          cpu: "1"
+          memory: "3Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 2
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 80
+      pdb:
+        maxUnavailable: 1
+      scratchVolume:
+        storage: "1Gi"
+    logfire-otel-collector:
+      resources:
+        cpu: "150m"
+        memory: "256Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          memAverage: 70
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
   standard:
     logfire-dex:
       resources:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -818,6 +818,7 @@ aiGatewayOauth:
 #   resources:
 #     cpu: "250m"
 #     memory: "512Mi"
+#     ephemeralStorage: "1Gi"
 #   autoscaling:
 #     minReplicas: 1
 #     maxReplicas: 5
@@ -1689,9 +1690,11 @@ sizingPresets:
         requests:
           cpu: "500m"
           memory: "768Mi"
+          ephemeral-storage: "1Gi"
         limits:
           cpu: "1500m"
           memory: "1Gi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -1701,6 +1704,15 @@ sizingPresets:
           cpuAverage: 60
       pdb:
         maxUnavailable: 1
+      scratchVolume:
+        storage: "1Gi"
+    logfire-ff-query-worker:
+      resources:
+        cpu: "500m"
+        memory: "768Mi"
+        ephemeralStorage: "1Gi"
+      scratchVolume:
+        storage: "1Gi"
     logfire-ff-crud-api:
       resources:
         cpu: "100m"
@@ -1732,9 +1744,11 @@ sizingPresets:
         requests:
           cpu: "250m"
           memory: "512Mi"
+          ephemeral-storage: "1Gi"
         limits:
           cpu: "1"
           memory: "512Mi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -1748,6 +1762,7 @@ sizingPresets:
       resources:
         cpu: "100m"
         memory: "256Mi"
+        ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -1802,6 +1817,7 @@ sizingPresets:
       resources:
         cpu: "250m"
         memory: "512Mi"
+        ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 1
@@ -1830,9 +1846,11 @@ sizingPresets:
         requests:
           cpu: "500m"
           memory: "2Gi"
+          ephemeral-storage: "1Gi"
         limits:
           cpu: "1"
           memory: "3Gi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 2
@@ -1911,6 +1929,25 @@ sizingPresets:
           cpuAverage: 25
       pdb:
         maxUnavailable: 1
+    logfire-ai-gateway:
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "500m"
+          memory: "1Gi"
+          ephemeral-storage: "1Gi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          memAverage: 65
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
     logfire-remote-mcp:
       resources:
         cpu: "250m"
@@ -1927,6 +1964,7 @@ sizingPresets:
       resources:
         cpu: "2"
         memory: "8Gi"
+        ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 2
         maxReplicas: 8
@@ -1936,6 +1974,15 @@ sizingPresets:
           cpuAverage: 60
       pdb:
         maxUnavailable: 1
+      scratchVolume:
+        storage: "6Gi"
+    logfire-ff-query-worker:
+      resources:
+        cpu: "500m"
+        memory: "4Gi"
+        ephemeralStorage: "1Gi"
+      scratchVolume:
+        storage: "6Gi"
     logfire-ff-crud-api:
       resources:
         cpu: "125m"
@@ -1967,9 +2014,11 @@ sizingPresets:
         requests:
           cpu: "250m"
           memory: "512Mi"
+          ephemeral-storage: "1Gi"
         limits:
           cpu: "1"
           memory: "512Mi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 5
@@ -2022,6 +2071,7 @@ sizingPresets:
       resources:
         cpu: "2"
         memory: "8Gi"
+        ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 16
@@ -2049,6 +2099,7 @@ sizingPresets:
       resources:
         cpu: "2"
         memory: "8Gi"
+        ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 16


### PR DESCRIPTION
## Summary
Adds `small` and `tiny` sizing presets for low-traffic self-hosted Logfire deployments, based on the existing standard sizing patterns but with lower replica counts and resource requests.