### PR TITLE
Sweep stale FF_TEMP_DIR scratch data on every fusionfire container start

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.24
+version: 0.13.25
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.24](https://img.shields.io/badge/Version-0.13.24-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
+![Version: 0.13.25](https://img.shields.io/badge/Version-0.13.25-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -268,3 +268,27 @@ Common execution env for background maintenance/compaction workers.
 "logfire-ff-migrations"
 {{- end -}}
 {{- end -}}
+
+{{/*
+Container command that sweeps stale FF_TEMP_DIR contents before starting fusionfire.
+
+The scratch volume (ephemeral PVC or emptyDir) is fresh when the pod is created but
+survives *container* restarts (e.g. OOM kills), and a SIGKILL skips tempfile's Drop
+cleanup - so a restarted container inherits orphaned scratch data that stays until
+the pod is deleted. Init containers only run at pod creation, so the sweep must run
+in the container command itself; keeping it in the chart (not the image entrypoint)
+means running the binary outside Kubernetes never deletes anything.
+
+The swept path comes from FF_TEMP_DIR at runtime so the script and the binary always
+agree on the location; workloads without FF_TEMP_DIR (e.g. the byte cache, whose
+/scratch mount holds reusable cache data) skip the sweep. `find` rather than a shell
+glob because tempfile names everything `.tmp*` and sh globs skip dotfiles.
+
+Emits the `command:` list entries; the fusionfire subcommand and flags stay in `args:`.
+*/}}
+{{- define "logfire.ffCommandWithTempDirCleanup" -}}
+- sh
+- -c
+- 'if [ -n "$FF_TEMP_DIR" ]; then find "$FF_TEMP_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + || true; fi; exec fusionfire "$@"'
+- fusionfire
+{{- end -}}

--- a/charts/logfire/templates/logfire-ff-compaction-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-compaction-worker.yaml
@@ -52,7 +52,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
 {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           command:
-            - fusionfire
+            {{- include "logfire.ffCommandWithTempDirCleanup" . | nindent 12 }}
+          args:
             - compaction-worker
             - --host=0.0.0.0
             - --port=8013

--- a/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
@@ -52,7 +52,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
 {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           command:
-            - fusionfire
+            {{- include "logfire.ffCommandWithTempDirCleanup" . | nindent 12 }}
+          args:
             - maintenance-worker
             - --host=0.0.0.0
             - --port=8013

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -77,7 +77,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           command:
-            - fusionfire
+            {{- include "logfire.ffCommandWithTempDirCleanup" . | nindent 12 }}
+          args:
             {{- if (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
             - query
             {{- else }}

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -58,7 +58,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           command:
-            - fusionfire
+            {{- include "logfire.ffCommandWithTempDirCleanup" . | nindent 12 }}
+          args:
             - query-worker
             - --host=0.0.0.0
             - --port=8011


### PR DESCRIPTION
## Problem

The fusionfire scratch volume (ephemeral PVC, or emptyDir when `scratchVolume` is unset) is fresh when a pod is created but **survives container restarts** — and an OOM kill (SIGKILL) skips `tempfile`'s Drop cleanup. A restarted worker therefore inherits orphaned `.tmp*` scratch data that occupies the volume until the pod itself is deleted. Observed in Pydantic's production: one OOM-killed compaction worker stranded 68G — 54% of its scratch volume — for the remaining life of the pod, while live jobs legitimately push the volume past 90%.

Init containers can't fix this (they only run at pod creation, when the volume is empty anyway), and baking the sweep into the image entrypoint would risk deleting data when the binary runs outside Kubernetes.

## Fix

New helper `logfire.ffCommandWithTempDirCleanup` wraps the container command for the four workloads that set `FF_TEMP_DIR` (query-api, query-worker, maintenance-worker, compaction-worker):

```sh
if [ -n "$FF_TEMP_DIR" ]; then find "$FF_TEMP_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + || true; fi; exec fusionfire "$@"
```

- Runs on **every container start**, including in-place restarts after OOM kills.
- Swept path comes from `FF_TEMP_DIR` at runtime, so script and binary always agree; the byte cache (which mounts `/scratch` for reusable cache data and has no `FF_TEMP_DIR`) skips the sweep entirely.
- `find` instead of a shell glob because `tempfile` names everything `.tmp*` and sh globs skip dotfiles.
- `exec` preserves PID-1 signal handling; the fusionfire subcommand and flags move unchanged to `args:`.

Ports pydantic/platform#23441 (same fix for our cloud Pulumi specs) to the self-hosted chart.

## Validation

- `helm lint` passes; `helm unittest charts/logfire` — 29/29 pass.
- `helm template` with `ci-values.yaml` verified: all four workloads render the wrapper with correct `args` (including the `query` vs `query-worker` conditional on query-api when `logfire-ff-query-worker.enabled=true`), and `cache-byte`/other fusionfire services keep their plain command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)