### PR TITLE
Delegate FusionFire sizing to auto-config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-16
     permissions:
       id-token: write
       contents: read
@@ -21,7 +21,8 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: latest
+          # v4.2.1 hangs during kind/local-path uninstall waits in chart-testing.
+          version: v4.2.0
 
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.26
+version: 0.13.26-rc.1
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.25
+version: 0.13.26
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.25](https://img.shields.io/badge/Version-0.13.25-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
+![Version: 0.13.26](https://img.shields.io/badge/Version-0.13.26-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -476,7 +476,9 @@ Before diving deeper, verify these common configuration issues:
 | logfire-dex.podAnnotations | object | `{}` | Pod annotations |
 | logfire-dex.podLabels | object | `{}` | Pod labels |
 | logfire-dex.service.annotations | object | `{}` | Service annotations |
-| logfire-ff-cache-byte | object | `{"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
+| logfire-ff-cache-byte | object | `{"pdb":{"minAvailable":2},"replicas":3,"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
+| logfire-ff-cache-byte.pdb | object | `{"minAvailable":2}` | Keep at least two byte-cache pods serving during voluntary disruptions. |
+| logfire-ff-cache-byte.replicas | int | `3` | Number of byte-cache replicas when autoscaling is not configured. |
 | logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume |
 | logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"16Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
 | logfire-ff-ingest-processor | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}}}` | Autoscaling & resources for the `logfire-ff-ingest-processor` pod |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.26](https://img.shields.io/badge/Version-0.13.26-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
+![Version: 0.13.26-rc.1](https://img.shields.io/badge/Version-0.13.26--rc.1-informational?style=flat-square) ![AppVersion: 55e50fa2](https://img.shields.io/badge/AppVersion-55e50fa2-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -74,6 +74,10 @@ logfire-ff-ingest:
     storage: "1Gi"
 
 logfire-ff-cache-byte:
+  autoscaling:
+    minReplicas: 1
+  pdb:
+    minAvailable: 0
   scratchVolume:
     storageClassName: standard
     storage: "1Gi"

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -5,34 +5,44 @@ Fusionfire Helpers
 Helpers specific to Fusionfire workloads and configuration.
 */}}
 
-{{- define "logfire.ffCompactionTiersValue" -}}
-{{- if (get (get .Values "logfire-ff-maintenance-worker" | default  dict) "compactionTiers") -}}
-{{- with (get (get .Values "logfire-ff-maintenance-worker" | default  dict) "compactionTiers") -}}
-{{ . | toJson }}
-{{- end -}}
-{{- else -}}
-[{"count_threshold":10,"size_threshold_bytes":"1KB"},{"count_threshold":10,"size_threshold_bytes":"10KB"},{"count_threshold":10,"size_threshold_bytes":"100KB"},{"count_threshold":10,"size_threshold_bytes":"1MB"},{"count_threshold":10,"size_threshold_bytes":"10MB"},{"count_threshold":10,"size_threshold_bytes":"100MB"}]
+{{/*
+No-preset installs without workload resources still need a synthetic resource
+baseline for FusionFire auto-config, because no Kubernetes resources are
+rendered for the workload.
+*/}}
+{{- define "logfire.ffUseNoPresetResourceFallback" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- if and (not (.Values.sizingPreset | default "")) (not (get $effectiveServiceValues "resources")) -}}
+true
 {{- end -}}
 {{- end -}}
 
 {{/*
-Resolve FF execution values. No-preset installs borrow tiny's FF-specific
-baseline when a workload has no resources, without rendering tiny's resources,
-autoscaling, PDBs, or scheduling rules.
+Conservative resource hints for no-preset/no-resource installs. Keep these
+independent from the sizing presets so preset resource changes do not silently
+increase FusionFire auto-config on installs that render no Kubernetes resources.
 */}}
-{{- define "logfire.ffDerivedServiceValues" -}}
-{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
-{{- $derived := deepCopy $effectiveServiceValues -}}
-{{- if and (not (.Values.sizingPreset | default "")) (not (get $effectiveServiceValues "resources")) -}}
-  {{- $tinyPreset := get (.Values.sizingPresets | default dict) "tiny" | default dict -}}
-  {{- $tinyServiceValues := get $tinyPreset .serviceName | default dict -}}
-  {{- range $key := list "queryParallelism" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" -}}
-    {{- if and (not (hasKey $derived $key)) (hasKey $tinyServiceValues $key) -}}
-      {{- $_ := set $derived $key (deepCopy (get $tinyServiceValues $key)) -}}
-    {{- end -}}
-  {{- end -}}
+{{- define "logfire.ffNoPresetResourceFallback" -}}
+{{- $fallbacks := dict
+  "logfire-ff-cache-byte" (dict "cpu" "250m" "memory" "384Mi")
+  "logfire-ff-compaction-worker" (dict "cpu" "1" "memory" "2Gi")
+  "logfire-ff-crud-api" (dict "cpu" "100m" "memory" "192Mi")
+  "logfire-ff-ingest" (dict "cpu" "250m" "memory" "512Mi")
+  "logfire-ff-ingest-processor" (dict "cpu" "350m" "memory" "512Mi")
+  "logfire-ff-maintenance-scheduler" (dict "cpu" "100m" "memory" "192Mi")
+  "logfire-ff-maintenance-worker" (dict "cpu" "1" "memory" "512Mi")
+  "logfire-ff-query-api" (dict "cpu" "500m" "memory" "768Mi")
+  "logfire-ff-query-worker" (dict "cpu" "500m" "memory" "768Mi")
+-}}
+{{- get $fallbacks .serviceName | default (dict "cpu" "500m" "memory" "1Gi") | toJson -}}
 {{- end -}}
-{{- $derived | toJson -}}
+
+{{- define "logfire.ffCompactionTiersValue" -}}
+{{- $maintenanceWorker := dict "Values" .Values "serviceName" "logfire-ff-maintenance-worker" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" $maintenanceWorker | fromJson -}}
+{{- if (get $effectiveServiceValues "compactionTiers") -}}
+{{- get $effectiveServiceValues "compactionTiers" | toJson -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "logfire.ffMaxCompactionJobSizeBytesDefault" -}}
@@ -45,38 +55,47 @@ autoscaling, PDBs, or scheduling rules.
 {{- end -}}
 
 {{- define "logfire.ffMaxCompactionJobSizeBytes" -}}
-{{- $maintenanceServiceValues := include "logfire.ffDerivedServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-maintenance-worker") | fromJson -}}
-{{- $compactionServiceValues := include "logfire.ffDerivedServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-compaction-worker") | fromJson -}}
+{{- $maintenanceServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-maintenance-worker") | fromJson -}}
+{{- $compactionServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-compaction-worker") | fromJson -}}
 {{- coalesce (get $compactionServiceValues "maxCompactionJobSizeBytes") (get $maintenanceServiceValues "maxCompactionJobSizeBytes") (include "logfire.ffMaxCompactionJobSizeBytesDefault" .) -}}
 {{- end -}}
 
 {{/*
-Derive FF service CPU core count and DataFusion thread count from the effective CPU request.
+Expose effective Kubernetes resources to FusionFire so its auto-config formulas
+use the same resources Kubernetes enforces. When no preset/resources are set,
+the chart does not render Kubernetes resources, so use conservative synthetic
+inputs instead.
 */}}
-{{- define "logfire.ffThreadSettings" -}}
+{{- define "logfire.ffResourceEnv" -}}
 {{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $cpu := get $effectiveResources "cpuRequest" -}}
-{{- $cpuCores := int (include "logfire.cpuCores" $cpu) -}}
-{{- $dataFusionThreads := max 1 (sub $cpuCores 1) -}}
-{{- dict "cpuCores" $cpuCores "dataFusionThreads" $dataFusionThreads | toJson -}}
+{{- $useFallback := include "logfire.ffUseNoPresetResourceFallback" . -}}
+{{- $fallbackResources := include "logfire.ffNoPresetResourceFallback" . | fromJson -}}
+{{- $cpu := ternary (get $fallbackResources "cpu") (get $effectiveResources "cpuLimit") (not (empty $useFallback)) -}}
+{{- $memory := ternary (get $fallbackResources "memory") (get $effectiveResources "memoryLimit") (not (empty $useFallback)) -}}
+{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
+{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
+- name: FF_RESOURCE_CPU_CORES
+  value: {{ printf "%.3f" (divf (float64 $cpuMilli) 1000.0) | quote }}
+- name: FF_RESOURCE_MEMORY_BYTES
+  value: {{ mul $memoryMi 1048576 | quote }}
+{{- end -}}
+
+{{- define "logfire.ffIoThreads" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- get $effectiveServiceValues "ioThreads" | default "auto" -}}
+{{- end -}}
+
+{{- define "logfire.ffDatafusionThreads" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- get $effectiveServiceValues "datafusionThreads" | default "auto" -}}
 {{- end -}}
 
 {{/*
-Default query parallelism follows the computed FF IO thread count.
-*/}}
-{{- define "logfire.ffQueryParallelismDefault" -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- mul $cpuCores 2 -}}
-{{- end -}}
-
-{{/*
-Resolve query parallelism from explicit service values, falling back to the computed default.
+Resolve query parallelism from explicit service values, falling back to FusionFire auto-config.
 */}}
 {{- define "logfire.ffQueryParallelism" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
-{{- $defaultQueryParallelism := include "logfire.ffQueryParallelismDefault" . -}}
-{{- get $effectiveServiceValues "queryParallelism" | default $defaultQueryParallelism -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- get $effectiveServiceValues "queryParallelism" | default "auto" -}}
 {{- end -}}
 
 {{/*
@@ -103,7 +122,7 @@ Resolve ingest direct-file buffering from explicit service values, falling back
 to computed defaults.
 */}}
 {{- define "logfire.ffIngestDirectFileSettings" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
 {{- $defaults := include "logfire.ffIngestDirectFileSettingsDefault" . | fromJson -}}
 {{- $bufferMaxBytes := get $effectiveServiceValues "directFileBufferMaxBytes" | default (get $defaults "bufferMaxBytes") -}}
 {{- $submitConcurrency := get $effectiveServiceValues "directFileSubmitConcurrency" | default (get $defaults "submitConcurrency") -}}
@@ -111,136 +130,21 @@ to computed defaults.
 {{- end -}}
 
 {{/*
-Resolve query-api parallelism. When dedicated query-workers are enabled,
-default from query-worker sizing because query-api schedules work onto workers.
-*/}}
-{{- define "logfire.ffQueryApiParallelism" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
-{{- $queryParallelismDefaultServiceName := .serviceName -}}
-{{- if (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") -}}
-{{- $queryParallelismDefaultServiceName = "logfire-ff-query-worker" -}}
-{{- end -}}
-{{- $queryParallelismDefault := include "logfire.ffQueryParallelismDefault" (dict "Values" .Values "serviceName" $queryParallelismDefaultServiceName) -}}
-{{- get $effectiveServiceValues "queryParallelism" | default $queryParallelismDefault -}}
-{{- end -}}
-
-{{/*
-Default DataFusion memory limit for query execution.
-Uses half the pod memory request, leaving headroom for the HTTP process/runtime.
-*/}}
-{{- define "logfire.ffQueryDatafusionMemoryDefault" -}}
-{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $memory := get $effectiveResources "memoryRequest" -}}
-{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
-{{- $datafusionMemoryMi := max 256 (div $memoryMi 2) -}}
-{{- printf "%dMB" $datafusionMemoryMi -}}
-{{- end -}}
-
-{{/*
-Default DataFusion memory cap for background maintenance/compaction workers.
-Larger workers use the pod memory limit so burstable workers can use their
-configured headroom. Sub-core workers use a smaller fraction to leave room for
-the process runtime, object store clients, decompression, and parquet writers.
-*/}}
-{{- define "logfire.ffBackgroundDatafusionMemoryDefault" -}}
-{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $cpu := get $effectiveResources "cpuRequest" -}}
-{{- $memory := get $effectiveResources "memoryLimit" -}}
-{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
-{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
-{{- $datafusionMemoryMi := 0 -}}
-{{- if lt $cpuMilli 1000 -}}
-  {{- if le $memoryMi 1024 -}}
-    {{- $datafusionMemoryMi = max 128 (div $memoryMi 2) -}}
-  {{- else -}}
-    {{- $datafusionMemoryMi = max 512 (div $memoryMi 8) -}}
-  {{- end -}}
-{{- else -}}
-{{- $datafusionMemoryMi = max 512 (div (mul $memoryMi 3) 8) -}}
-{{- end -}}
-{{- printf "%dMB" $datafusionMemoryMi -}}
-{{- end -}}
-
-{{/*
-Default DataFusion memory cap for the maintenance scheduler.
-The scheduler scans metadata rather than running compaction jobs, so it follows
-the pod memory request directly with a cap matching the previous chart default.
-*/}}
-{{- define "logfire.ffMaintenanceSchedulerDatafusionMemoryDefault" -}}
-{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $memory := get $effectiveResources "memoryRequest" -}}
-{{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
-{{- $datafusionMemoryMi := min 512 (max 128 $memoryMi) -}}
-{{- printf "%dMB" $datafusionMemoryMi -}}
-{{- end -}}
-
-{{/*
-Default background maintenance/compaction job concurrency.
-Sub-core workers stay conservative. Larger workers get enough queue parallelism
-to keep CPU-heavy phases fed while CPU concurrency still gates active compute.
-*/}}
-{{- define "logfire.ffBackgroundJobParallelismDefault" -}}
-{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
-{{- $cpu := get $effectiveResources "cpuRequest" -}}
-{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- if lt $cpuMilli 1000 -}}
-1
-{{- else -}}
-{{- min 10 (max 4 (mul $cpuCores 4)) -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Resolve background maintenance/compaction job concurrency from explicit service values,
-falling back to the computed default.
-*/}}
-{{- define "logfire.ffBackgroundJobParallelism" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
-{{- $defaultJobParallelism := include "logfire.ffBackgroundJobParallelismDefault" . -}}
-{{- get $effectiveServiceValues "jobParallelism" | default $defaultJobParallelism -}}
-{{- end -}}
-
-{{/*
-Default number of CPU-heavy maintenance phases to run concurrently.
-Uses roughly 75% of the effective CPU request, rounded to cores, with a
-minimum of one so sub-core workers can still make progress.
-*/}}
-{{- define "logfire.ffBackgroundCpuConcurrencyDefault" -}}
-{{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $cpu := get $effectiveResources "cpuRequest" -}}
-{{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
-{{- max 1 (div (add (mul $cpuMilli 3) 2000) 4000) -}}
-{{- end -}}
-
-{{/*
-Resolve CPU-heavy maintenance concurrency from explicit service values, falling
-back to the computed default.
-*/}}
-{{- define "logfire.ffBackgroundCpuConcurrency" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
-{{- $defaultCpuConcurrency := include "logfire.ffBackgroundCpuConcurrencyDefault" . -}}
-{{- get $effectiveServiceValues "cpuConcurrency" | default $defaultCpuConcurrency -}}
-{{- end -}}
-
-{{/*
 Common execution env for background maintenance/compaction workers.
 */}}
 {{- define "logfire.ffBackgroundWorkerExecutionEnv" -}}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" . | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" . | fromJson -}}
-{{- $defaultDatafusionMemory := include "logfire.ffBackgroundDatafusionMemoryDefault" . -}}
-{{- $datafusionMemory := get $effectiveServiceValues "datafusionMemory" | default $defaultDatafusionMemory -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- $datafusionMemory := get $effectiveServiceValues "datafusionMemory" | default "auto" -}}
 {{- $recordBatchMemory := get $effectiveServiceValues "maintenanceRecordBatchMemory" | default $datafusionMemory -}}
-{{- $jobParallelism := include "logfire.ffBackgroundJobParallelism" . -}}
-{{- $cpuConcurrency := include "logfire.ffBackgroundCpuConcurrency" . -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $jobParallelism := get $effectiveServiceValues "jobParallelism" | default "auto" -}}
+{{- $cpuConcurrency := get $effectiveServiceValues "cpuConcurrency" | default "auto" -}}
+{{- $ioThreads := include "logfire.ffIoThreads" . -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" . -}}
+{{- include "logfire.ffResourceEnv" . }}
 - name: FF_IO_THREADS
-  value: {{ $cpuCores | quote }}
+  value: {{ $ioThreads | quote }}
 - name: FF_DATAFUSION_THREADS
-  value: {{ $dataFusionThreads | quote }}
+  value: {{ $datafusionThreads | quote }}
 - name: FF_DATAFUSION_MEMORY_LIMIT
   value: {{ $datafusionMemory | quote }}
 - name: FF_MAINTENANCE_MAX_RECORD_BATCH_MEMORY

--- a/charts/logfire/templates/_helpers-resources.tpl
+++ b/charts/logfire/templates/_helpers-resources.tpl
@@ -32,14 +32,6 @@ Accepts values like 1, 0.5, 750m.
 {{- end -}}
 
 {{/*
-Convert Kubernetes CPU quantity to integer cores using ceil, with minimum 1.
-*/}}
-{{- define "logfire.cpuCores" -}}
-{{- $cpuMilli := int (include "logfire.cpuMilli" .) -}}
-{{- max 1 (div (add $cpuMilli 999) 1000) -}}
-{{- end -}}
-
-{{/*
 Resolve effective resource requests/limits for a workload.
 Supports both legacy flat keys and nested requests/limits.
 When resources are omitted entirely, use the tiny preset's resources as the

--- a/charts/logfire/templates/_helpers-validation.tpl
+++ b/charts/logfire/templates/_helpers-validation.tpl
@@ -149,6 +149,20 @@ Validate gateway secret configuration
 
 
 {{/*
+Validate scratch volume configuration.
+*/}}
+{{- define "logfire.validate.scratchVolumes" -}}
+{{- range $serviceName := list "logfire-ff-cache-byte" "logfire-ff-compaction-worker" "logfire-ff-maintenance-worker" "logfire-ff-query-api" "logfire-ff-query-worker" -}}
+  {{- $serviceValues := include "logfire.effectiveServiceValues" (dict "Values" $.Values "serviceName" $serviceName) | fromJson -}}
+  {{- $scratchVolume := get $serviceValues "scratchVolume" | default dict -}}
+  {{- if and $scratchVolume (not (get $scratchVolume "storage")) -}}
+    {{- fail (printf "%s.scratchVolume.storage is required when scratchVolume is configured. Omit %s.scratchVolume to use emptyDir scratch storage, or set scratchVolume.storage for an ephemeral PVC." $serviceName $serviceName) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Validate autoscaling configuration - warn if both HPA and KEDA are enabled
 */}}
 {{- define "logfire.validate.sizingPreset" -}}
@@ -323,6 +337,7 @@ Call this from templates that need to ensure configuration is valid.
   "logfire.validate.admin"
   "logfire.validate.redis"
   "logfire.validate.inClusterTls"
+  "logfire.validate.scratchVolumes"
   -}}
 {{- range $validator := $validators -}}
 {{- include $validator $root -}}

--- a/charts/logfire/templates/logfire-ff-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-byte.yaml
@@ -74,15 +74,13 @@ spec:
             - byte-cache
             - --host=0.0.0.0
             - --port=9001
-            - --cache-size={{ include "logfire.calculateMemory" (dict "Values" .Values "serviceName" $serviceName "percentage" 70) }}MB
-            - --in-flight-size={{ include "logfire.calculateMemory" (dict "Values" .Values "serviceName" $serviceName "percentage" 20) }}MB
-            - --file-size-cache-size={{ include "logfire.calculateMemory" (dict "Values" .Values "serviceName" $serviceName "percentage" 5) }}MB
           envFrom:
             - configMapRef:
                 name: logfire-ff-base-config
           env:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             {{- include "logfire.objectStoreEnv" . | nindent 12 }}
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: OTEL_TRACES_SAMPLER
               value: parentbased_traceidratio
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -66,7 +66,9 @@ metadata:
 data:
   FF_CACHE_OBJECT_STORE_HTTP_HEADERS: x-ff-no-warm-cache=1
   FF_COMPACTION_LOOP_BACKOFF_DELAY: "1s"
-  FF_COMPACTION_TIERS: {{ include "logfire.ffCompactionTiersValue" . | squote }}
+  {{- with (include "logfire.ffCompactionTiersValue" .) }}
+  FF_COMPACTION_TIERS: {{ . | squote }}
+  {{- end }}
   FF_MAX_COMPACTION_JOB_SIZE_BYTES: {{ include "logfire.ffMaxCompactionJobSizeBytes" . | quote }}
   FF_INGEST_MAX_TIME_SKEW: "120s"
 

--- a/charts/logfire/templates/logfire-ff-crud-api.yaml
+++ b/charts/logfire/templates/logfire-ff-crud-api.yaml
@@ -110,6 +110,7 @@ spec:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: FF_DATAFUSION_THREAD_STACK_SIZE
               value: "8MB" 
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             {{- with (index .Values $serviceName | default dict).env }}
               {{- . | toYaml | nindent 12 }}
             {{- end}}

--- a/charts/logfire/templates/logfire-ff-ingest-processor.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest-processor.yaml
@@ -1,7 +1,6 @@
 {{- $serviceName := "logfire-ff-ingest-processor" }}
-{{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 
 apiVersion: v1
 kind: Service
@@ -103,10 +102,11 @@ spec:
             - name: OTEL_TRACES_SAMPLER
               value: "parentbased_traceidratio"
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_IO_THREADS
-              value: {{ $cpuCores | quote }}
+              value: {{ $ioThreads | quote }}
             - name: FF_DATAFUSION_THREADS
-              value: {{ $dataFusionThreads | quote }}
+              value: {{ $datafusionThreads | quote }}
             - name: PG_DSN
               valueFrom:
                 secretKeyRef:

--- a/charts/logfire/templates/logfire-ff-ingest.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest.yaml
@@ -1,10 +1,9 @@
 {{- $serviceName := "logfire-ff-ingest" }}
 {{- $serviceValues := get .Values $serviceName | default dict -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $directFileSettings := include "logfire.ffIngestDirectFileSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 
 apiVersion: v1
 kind: Service
@@ -115,10 +114,11 @@ spec:
               value: {{ get $directFileSettings "bufferMaxBytes" | quote }}
             - name: FF_DIRECT_FILE_INGEST_SUBMIT_CONCURRENCY
               value: {{ get $directFileSettings "submitConcurrency" | quote }}
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_IO_THREADS
-              value: {{ $cpuCores | quote }}
+              value: {{ $ioThreads | quote }}
             - name: FF_DATAFUSION_THREADS
-              value: {{ $dataFusionThreads | quote }}
+              value: {{ $datafusionThreads | quote }}
             - name: PG_DSN
               valueFrom:
                 secretKeyRef:

--- a/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
@@ -1,9 +1,7 @@
 {{- $serviceName := "logfire-ff-maintenance-scheduler" }}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $defaultDatafusionMemory := include "logfire.ffMaintenanceSchedulerDatafusionMemoryDefault" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,10 +70,11 @@ spec:
             - configMapRef:
                 name: logfire-ff-maintenance-config
           env:
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_IO_THREADS
-              value: {{ $cpuCores | quote }}
+              value: {{ $ioThreads | quote }}
             - name: FF_DATAFUSION_THREADS
-              value: {{ $dataFusionThreads | quote }}
+              value: {{ $datafusionThreads | quote }}
             - name: FF_COMPACTION_MAX_DAYS
               value: "3"
             - name: FF_MAX_PARTITIONS_PER_COMPACTION_SCAN
@@ -87,7 +86,7 @@ spec:
             - name: FF_MAINTENANCE_SCHEDULING_CONCURRENCY
               value: "1"
             - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default $defaultDatafusionMemory | quote) }}
+              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: PG_DSN
               valueFrom:

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -1,10 +1,8 @@
 {{- $serviceName := "logfire-ff-query-api" }}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $queryParallelism := include "logfire.ffQueryApiParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $defaultDatafusionMemory := include "logfire.ffQueryDatafusionMemoryDefault" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -103,13 +101,14 @@ spec:
               value: /scratch/fusionfire
             - name: FF_QUERY_PARALLELISM
               value: {{ $queryParallelism | quote }}
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             {{- if not (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
             - name: FF_IO_THREADS
-              value: {{ $cpuCores | quote }}
+              value: {{ $ioThreads | quote }}
             - name: FF_DATAFUSION_THREADS
-              value: {{ $dataFusionThreads | quote }}
+              value: {{ $datafusionThreads | quote }}
             - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default $defaultDatafusionMemory | quote) }}
+              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
             - name: FF_IO_THREAD_STACK_SIZE
               value: "8MB"
             {{- end }}

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -1,10 +1,8 @@
 {{- $serviceName := "logfire-ff-query-worker" }}
-{{- $effectiveServiceValues := include "logfire.ffDerivedServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $threadSettings := include "logfire.ffThreadSettings" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $defaultDatafusionMemory := include "logfire.ffQueryDatafusionMemoryDefault" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $cpuCores := int (get $threadSettings "cpuCores") -}}
-{{- $dataFusionThreads := int (get $threadSettings "dataFusionThreads") -}}
+{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- if (index .Values $serviceName | default dict).enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -80,14 +78,15 @@ spec:
               value: /scratch/fusionfire
             - name: FF_QUERY_PARALLELISM
               value: {{ $queryParallelism | quote }}
+            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_PG_POOL_MAX_CONNECTIONS
               value: "4"
             - name: FF_IO_THREADS
-              value: {{ $cpuCores | quote }}
+              value: {{ $ioThreads | quote }}
             - name: FF_DATAFUSION_THREADS
-              value: {{ $dataFusionThreads | quote }}
+              value: {{ $datafusionThreads | quote }}
             - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default $defaultDatafusionMemory | quote) }}
+              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
             - name: FF_DATAFUSION_THREAD_STACK_SIZE
               value: "8MB"
             - name: FF_IO_THREAD_STACK_SIZE

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -742,10 +742,10 @@ logfire-remote-mcp:
 #   service:
 #     # -- Service annotations
 #     annotations: {}
-#   # -- Parallelism per pod. Defaults to 2x computed FF_IO_THREADS.
+#   # -- Parallelism per pod. Defaults to FusionFire auto-config from effective CPU.
 #   # queryParallelism: 4
 #   # -- DataFusion memory limit when query-workers are disabled and query-api runs in query-worker mode.
-#   # Defaults to half of the pod memory request, with a 256MB floor.
+#   # Defaults to FusionFire auto-config from effective memory.
 #   # datafusionMemory: "4096MB"
 #   # -- Number of replicas
 #   replicas: 2
@@ -899,13 +899,13 @@ logfire-ff-cache-byte:
 #   podLabels: {}
 #   # -- Pod annotations
 #   podAnnotations: {}
-#   # -- Number of replicas
-#   replicas: 2
+  # -- Number of byte-cache replicas when autoscaling is not configured.
+  replicas: 3
 #   resources:
 #     cpu: "1"
 #     memory: "5Gi"
 #   autoscaling:
-#     minReplicas: 1
+#     minReplicas: 3
 #     maxReplicas: 6
 #     hpa:
 #       enabled: true
@@ -923,8 +923,10 @@ logfire-ff-cache-byte:
 #   tolerations: []
 #   pdb:
 #     maxUnavailable: 1
-#     minAvailable: 1
-# -- Cache byte ephemeral volume
+  # -- Keep at least two byte-cache pods serving during voluntary disruptions.
+  pdb:
+    minAvailable: 2
+  # -- Cache byte ephemeral volume
   scratchVolume:
     storage: 32Gi
     #  storageClassName: my-storage-class
@@ -982,18 +984,16 @@ logfire-ff-cache-byte:
 #   podLabels: {}
 #   # -- Pod annotations
 #   podAnnotations: {}
-#   # -- Compaction job concurrency. Defaults from CPU request: 1 for sub-core workers,
-#   # otherwise CPU cores + 1, bounded between 3 and 10.
+#   # -- Compaction job concurrency. Defaults to FusionFire auto-config from effective CPU.
 #   # jobParallelism: 3
-#   # -- CPU-heavy maintenance phase concurrency. Defaults to roughly 75% of CPU request, minimum 1.
+#   # -- CPU-heavy maintenance phase concurrency. Defaults to FusionFire auto-config from effective CPU.
 #   # cpuConcurrency: 2
 #   # -- Threshold for spilling parquet encode buffers to the scratch volume.
 #   # parquetSpoolThresholdBytes: "1MB"
 #   replicas: 2
-#   # -- DataFusion memory limit. Defaults from CPU and memory resources: sub-core workers
-#   # use conservative memory fractions, larger workers use 3/8 of the pod memory limit.
+#   # -- DataFusion memory limit. Defaults to FusionFire auto-config from effective memory.
 #   # datafusionMemory: "3072MB"
-#   # -- Record-batch memory limiter. Defaults to the computed DataFusion memory limit.
+#   # -- Record-batch memory limiter. Defaults to FusionFire auto-config from effective memory.
 #   # maintenanceRecordBatchMemory: "3072MB"
 #   # -- Maximum compressed input bytes to schedule into one compaction job.
 #   # Defaults from compaction-worker memory request when sizing is configured, bounded between 32MB and 512MB.
@@ -1053,18 +1053,16 @@ logfire-ff-cache-byte:
 #   podLabels: {}
 #   # -- Pod annotations
 #   podAnnotations: {}
-#   # -- Compaction job concurrency. Defaults from CPU request: 1 for sub-core workers,
-#   # otherwise CPU cores + 1, bounded between 3 and 10.
+#   # -- Compaction job concurrency. Defaults to FusionFire auto-config from effective CPU.
 #   # jobParallelism: 3
-#   # -- CPU-heavy maintenance phase concurrency. Defaults to roughly 75% of CPU request, minimum 1.
+#   # -- CPU-heavy maintenance phase concurrency. Defaults to FusionFire auto-config from effective CPU.
 #   # cpuConcurrency: 2
 #   # -- Threshold for spilling parquet encode buffers to the scratch volume.
 #   # parquetSpoolThresholdBytes: "1MB"
 #   replicas: 2
-#   # -- DataFusion memory limit. Defaults from CPU and memory resources: sub-core workers
-#   # use conservative memory fractions, larger workers use 3/8 of the pod memory limit.
+#   # -- DataFusion memory limit. Defaults to FusionFire auto-config from effective memory.
 #   # datafusionMemory: "3072MB"
-#   # -- Record-batch memory limiter. Defaults to the computed DataFusion memory limit.
+#   # -- Record-batch memory limiter. Defaults to FusionFire auto-config from effective memory.
 #   # maintenanceRecordBatchMemory: "3072MB"
 #   # -- Maximum compressed input bytes to schedule into one compaction job.
 #   # Defaults from compaction-worker memory request when sizing is configured, bounded between 32MB and 512MB.
@@ -1712,7 +1710,7 @@ sizingPresets:
         storage: "1Gi"
     logfire-ff-compaction-worker:
       resources:
-        cpu: "300m"
+        cpu: "1"
         memory: "768Mi"
       autoscaling:
         minReplicas: 1
@@ -1739,8 +1737,8 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-ingest:
       resources:
-        cpu: "250m"
-        memory: "512Mi"
+        cpu: "500m"
+        memory: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -1752,8 +1750,8 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-ingest-processor:
       resources:
-        cpu: "350m"
-        memory: "512Mi"
+        cpu: "1"
+        memory: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -1796,15 +1794,14 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
-      queryParallelism: 4
       resources:
         requests:
-          cpu: "500m"
-          memory: "768Mi"
+          cpu: "1"
+          memory: "2Gi"
           ephemeral-storage: "1Gi"
         limits:
-          cpu: "1500m"
-          memory: "1Gi"
+          cpu: "2"
+          memory: "3Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -1903,14 +1900,14 @@ sizingPresets:
       scratchVolume:
         storage: "1Gi"
       autoscaling:
-        minReplicas: 1
+        minReplicas: 3
         maxReplicas: 6
         hpa:
           enabled: true
           memAverage: 65
           cpuAverage: 25
       pdb:
-        maxUnavailable: 1
+        minAvailable: 2
     logfire-ff-proxy-cache-byte:
       resources:
         cpu: "150m"
@@ -1926,8 +1923,8 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-maintenance-worker:
       resources:
-        cpu: "250m"
-        memory: "512Mi"
+        cpu: "1"
+        memory: "1Gi"
         ephemeralStorage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -1955,12 +1952,12 @@ sizingPresets:
     logfire-ff-compaction-worker:
       resources:
         requests:
-          cpu: "500m"
-          memory: "2Gi"
+          cpu: "1"
+          memory: "4Gi"
           ephemeral-storage: "1Gi"
         limits:
-          cpu: "1"
-          memory: "3Gi"
+          cpu: "2"
+          memory: "4Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2081,7 +2078,6 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
-      queryParallelism: 4
       resources:
         requests:
           cpu: "1"
@@ -2206,14 +2202,14 @@ sizingPresets:
       scratchVolume:
         storage: "4Gi"
       autoscaling:
-        minReplicas: 1
+        minReplicas: 3
         maxReplicas: 8
         hpa:
           enabled: true
           memAverage: 65
           cpuAverage: 25
       pdb:
-        maxUnavailable: 1
+        minAvailable: 2
     logfire-ff-proxy-cache-byte:
       resources:
         cpu: "500m"
@@ -2229,7 +2225,7 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-maintenance-worker:
       resources:
-        cpu: "500m"
+        cpu: "1"
         memory: "1Gi"
         ephemeralStorage: "1Gi"
       autoscaling:
@@ -2590,7 +2586,7 @@ sizingPresets:
         cpu: "1"
         memory: "5Gi"
       autoscaling:
-        minReplicas: 1
+        minReplicas: 3
         maxReplicas: 6
         hpa:
           enabled: true
@@ -2598,6 +2594,8 @@ sizingPresets:
           cpuAverage: 25
       scratchVolume:
         storage: 32Gi
+      pdb:
+        minAvailable: 2
     logfire-ff-proxy-cache-byte:
       resources:
         cpu: "750m"


### PR DESCRIPTION
## Summary
Update chart internal settings

## Upgrade notes
No changes required 


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delegate FusionFire sizing to auto-config across all services
> - Replaces chart-computed thread counts, memory limits, and parallelism defaults with `"auto"` across ingest, query, maintenance, and compaction services, letting FusionFire self-configure based on runtime resources.
> - Adds a new `logfire.ffResourceEnv` helper that derives `FF_RESOURCE_CPU_CORES` and `FF_RESOURCE_MEMORY_BYTES` from Kubernetes limits (falling back to requests) and injects them into all service pods.
> - Removes the `logfire.ffCompactionTiersValue` helper and related helpers; `FF_COMPACTION_TIERS` is now omitted when `compactionTiers` is not set in values, deferring to FusionFire's internal default.
> - Sets `logfire-ff-cache-byte` default replicas to 3 with a PDB `minAvailable` of 2, and removes explicit `--cache-size`/`--in-flight-size`/`--file-size-cache-size` flags from byte-cache pods.
> - Increases CPU and memory in several sizing presets (ingest, ingest-processor, query-api, maintenance-worker, compaction-worker) and removes hard-coded `queryParallelism` from some presets.
> - Behavioral Change: services that previously had chart-computed numeric thread/memory/parallelism values now receive `"auto"` or nothing, shifting sizing responsibility to the application.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e591ce7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->