### PR TITLE
Tune preset resource defaults

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.27-rc.1
+version: 0.13.27-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.27-rc.1](https://img.shields.io/badge/Version-0.13.27--rc.1-informational?style=flat-square) ![AppVersion: 4c2b710a](https://img.shields.io/badge/AppVersion-4c2b710a-informational?style=flat-square)
+![Version: 0.13.27-rc.2](https://img.shields.io/badge/Version-0.13.27--rc.2-informational?style=flat-square) ![AppVersion: 4c2b710a](https://img.shields.io/badge/AppVersion-4c2b710a-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1941,7 +1941,7 @@ sizingPresets:
       resources:
         requests:
           cpu: "1"
-          memory: "2Gi"
+          memory: "6Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2237,7 +2237,7 @@ sizingPresets:
       resources:
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "12Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2622,7 +2622,7 @@ sizingPresets:
       resources:
         requests:
           cpu: "3"
-          memory: "8Gi"
+          memory: "18Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1957,7 +1957,7 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
       scratchVolume:
-        storage: "1Gi"
+        storage: "16Gi"
     logfire-ff-maintenance-scheduler:
       resources:
         requests:
@@ -2257,7 +2257,7 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
       scratchVolume:
-        storage: "2Gi"
+        storage: "32Gi"
     logfire-ff-maintenance-scheduler:
       resources:
         requests:
@@ -2641,7 +2641,7 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
       scratchVolume:
-        storage: "4Gi"
+        storage: "64Gi"
     logfire-ff-maintenance-scheduler:
       resources:
         requests:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1819,10 +1819,6 @@ sizingPresets:
           cpu: "1"
           memory: "2Gi"
           ephemeral-storage: "1Gi"
-        limits:
-          cpu: "2"
-          memory: "3Gi"
-          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -1945,7 +1941,7 @@ sizingPresets:
       resources:
         requests:
           cpu: "1"
-          memory: "1Gi"
+          memory: "2Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2101,10 +2097,6 @@ sizingPresets:
           cpu: "1"
           memory: "2Gi"
           ephemeral-storage: "1Gi"
-        limits:
-          cpu: "2"
-          memory: "3Gi"
-          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 8
@@ -2244,8 +2236,8 @@ sizingPresets:
     logfire-ff-maintenance-worker:
       resources:
         requests:
-          cpu: "1"
-          memory: "1Gi"
+          cpu: "2"
+          memory: "4Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2466,9 +2458,10 @@ sizingPresets:
               app.kubernetes.io/component: logfire-remote-mcp
     logfire-ff-query-api:
       resources:
-        cpu: "2"
-        memory: "8Gi"
-        ephemeralStorage: "1Gi"
+        requests:
+          cpu: "2"
+          memory: "8Gi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 8
@@ -2628,7 +2621,7 @@ sizingPresets:
     logfire-ff-maintenance-worker:
       resources:
         requests:
-          cpu: "2"
+          cpu: "3"
           memory: "8Gi"
           ephemeral-storage: "1Gi"
       autoscaling:


### PR DESCRIPTION
- bump chart prerelease version to `0.13.27-rc.2`
- match maintenance worker scratch storage to compaction worker scratch storage in tiny, small, and standard presets
- raise maintenance worker preset resources to the tested CPU:memory shapes:
  - tiny: `1 CPU / 6Gi`
  - small: `2 CPU / 12Gi`
  - standard: `3 CPU / 18Gi`
