### PR TITLE
0.9.12: bump appVersion to dba4f9cb

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.9.11
+version: 0.9.12
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "d7fd41e4"
+appVersion: "dba4f9cb"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
Patch release of the `0.9` line: bumps `appVersion` to `dba4f9cb`, a newer build of the same `0.9`-line application. **No chart template changes** — operators on `0.9.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.9.12
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.9`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the `logfire-*` release commit so the diff is just the `Chart.yaml` bump._