### PR TITLE
0.10.6: bump appVersion to 742309f8

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.10.5
+version: 0.10.6
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "pr-a8ce523f"
+appVersion: "742309f8"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
Patch release of the `0.10` line: bumps `appVersion` to `742309f8`, a newer build of the same `0.10`-line application. **No chart template changes** — operators on `0.10.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.10.6
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.10`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the `logfire-*` release commit so the diff is just the `Chart.yaml` bump._