### PR TITLE
0.11.4: bump appVersion to 986c4d4b

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.11.3
+version: 0.11.4
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "pr-90d0e519"
+appVersion: "986c4d4b"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
Patch release of the `0.11` line: bumps `appVersion` to `986c4d4b`, a newer build of the same `0.11`-line application. **No chart template changes** — operators on `0.11.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.11.4
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.11`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the `logfire-*` release commit so the diff is just the `Chart.yaml` bump._