### PR TITLE
0.8.10: bump appVersion to 9b9aff00

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.8.9
+version: 0.8.10
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "4d45960b"
+appVersion: "9b9aff00"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
Patch release of the `0.8` line: bumps `appVersion` to `9b9aff00`, a newer build of the same `0.8`-line application. **No chart template changes** — operators on `0.8.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.8.10
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.8`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the release commit so the diff is just the `Chart.yaml` bump._