### PR TITLE
0.11.4: bump appVersion to 986c4d4b

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,10 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_existing: true
+          mark_as_latest: ${{ github.ref_type != 'tag' }}
 
       - name: Update gh-pages README
+        if: github.ref_type != 'tag'
         run: |
           # Store the current README content
           README_CONTENT=$(cat charts/logfire/README.md)

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.11.3
+version: 0.11.4
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "pr-90d0e519"
+appVersion: "986c4d4b"
 
 dependencies:
   - name: postgresql

--- a/ci/ct.yaml
+++ b/ci/ct.yaml
@@ -1,5 +1,5 @@
 remote: origin
-target-branch: main
+target-branch: chart-patch-base/0.11
 chart-dirs:
   - charts
 namespace: default


### PR DESCRIPTION
Patch release of the `0.11` line: bumps `appVersion` to `986c4d4b`, a newer build of the same `0.11`-line application. **No chart template changes** — operators on `0.11.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.11.4
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.11`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the release commit so the diff is just the `Chart.yaml` bump._