### PR TITLE
0.12.10: bump appVersion to 7ccdffda

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_existing: true
+          mark_as_latest: ${{ github.ref_type != 'tag' }}
 
       - name: Update release notes from PR body
         uses: actions/github-script@v7
@@ -155,6 +156,7 @@ jobs:
             });
 
       - name: Update gh-pages README
+        if: github.ref_type != 'tag'
         run: |
           # Store the current README content
           README_CONTENT=$(cat charts/logfire/README.md)

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-version: 0.12.9
+version: 0.12.10
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "47872889"
+appVersion: "7ccdffda"
 
 dependencies:
   - name: postgresql

--- a/ci/ct.yaml
+++ b/ci/ct.yaml
@@ -1,5 +1,5 @@
 remote: origin
-target-branch: main
+target-branch: chart-patch-base/0.12
 chart-dirs:
   - charts
 namespace: default


### PR DESCRIPTION
Patch release of the `0.12` line: bumps `appVersion` to `7ccdffda`, a newer build of the same `0.12`-line application. **No chart template changes** — operators on `0.12.x` can update within their minor with no breaking changes.

## Upgrade notes

```sh
helm repo update pydantic
helm upgrade logfire pydantic/logfire --version 0.12.10
```

Data-safe; no migration required.

---
_Draft. Publish from this `0.12`-line chart source (not by merging to main — `chart-releaser` packages main's current templates). Base is an empty commit at the release commit so the diff is just the `Chart.yaml` bump._