### PR TITLE
migrations: switch backend migration command from `uv run` to `python`

### DIFF
--- a/charts/logfire/templates/logfire-backend-migrations.yaml
+++ b/charts/logfire/templates/logfire-backend-migrations.yaml
@@ -45,9 +45,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command:
-            - "uv"
-            - "run"
-            - "--no-sync"
+            - "python"
             - "src/packages/logfire-db/logfire_db/migrations/main.py"
           env:
             - name: LOGFIRE_SEND_TO_LOGFIRE


### PR DESCRIPTION
## Summary

Pairs with [pydantic/platform#26663](https://github.com/pydantic/platform/pull/26663), which slims the `python-prod` image by dropping `uv`, `git`, and other build tooling.

The `logfire-backend-migrations` Job is the only place in this chart that was still calling `uv run --no-sync ...` — every other service template already uses `python -m ...`. This switches the migration Job to plain `python ...` so it keeps working on the leaner image.

## Behavior

Both invocations resolve to the same interpreter on the prod image:

- `uv run --no-sync src/packages/logfire-db/logfire_db/migrations/main.py` (old)
- `python src/packages/logfire-db/logfire_db/migrations/main.py` (new)

The prod image sets `ENV PATH=/app/.venv/bin:$PATH`, so `python` is `/app/.venv/bin/python` — the same interpreter `uv run --no-sync` was invoking. The migration script hasn't changed.

## Coordination with the platform PR

- Once [pydantic/platform#26663](https://github.com/pydantic/platform/pull/26663) merges and a `python-prod:*` image is published from `main`, the old chart command (`uv run …`) will fail on that image because there is no `uv` binary.
- This PR should land **at or before** the first chart release that pins to a `main`-cut `python-prod` image tag. Kept as **draft** until #26663 is merged and a tag is available.

## Verification

- Confirmed only one `uv run` reference exists in the chart templates (this file). Every other workload (`logfire-backend`, `logfire-worker`, `logfire-remote-mcp`, etc.) already uses `python -m ...` or a direct binary.
- On the platform PR, ran `python /app/src/packages/logfire-db/logfire_db/migrations/main.py` against a locally-built `python-prod` image — the script enumerates all 336 migrations before hitting the DB (fails only at DB-connect, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)