### PR TITLE
query api preset tuning

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.32
+version: 0.13.33
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.32](https://img.shields.io/badge/Version-0.13.32-informational?style=flat-square) ![AppVersion: 18c3a230](https://img.shields.io/badge/AppVersion-18c3a230-informational?style=flat-square)
+![Version: 0.13.33](https://img.shields.io/badge/Version-0.13.33-informational?style=flat-square) ![AppVersion: 18c3a230](https://img.shields.io/badge/AppVersion-18c3a230-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -137,6 +137,22 @@ Resolve query parallelism from explicit service values, falling back to FusionFi
 {{- end -}}
 
 {{/*
+Optional DataFusion query execution overrides. When omitted, FusionFire keeps
+its own defaults and auto-config behavior.
+*/}}
+{{- define "logfire.ffQueryExecutionEnv" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- if hasKey $effectiveServiceValues "datafusionTargetPartitions" }}
+- name: FF_DATAFUSION_TARGET_PARTITIONS
+  value: {{ get $effectiveServiceValues "datafusionTargetPartitions" | quote }}
+{{- end }}
+{{- if hasKey $effectiveServiceValues "datafusionBatchSize" }}
+- name: FF_DATAFUSION_BATCH_SIZE
+  value: {{ get $effectiveServiceValues "datafusionBatchSize" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Default ingest direct-file buffering.
 Sizes batch files from the pod memory request, then caps replay/submit
 concurrency from both memory and CPU so sub-core ingest pods do not overwhelm

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -121,7 +121,7 @@ Only sizing and portable availability keys are inherited from presets.
     {{- $presetValues = mergeOverwrite (deepCopy (get $presets "standard")) (deepCopy $presetValues) -}}
   {{- end -}}
   {{- $presetServiceValues := get $presetValues $serviceName | default dict -}}
-  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "queryParallelism" "datafusionThreads" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
+  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "queryParallelism" "datafusionThreads" "datafusionTargetPartitions" "datafusionBatchSize" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
     {{- if hasKey $presetServiceValues $key -}}
       {{- $_ := set $merged $key (deepCopy (get $presetServiceValues $key)) -}}
     {{- end -}}

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -96,6 +96,7 @@ spec:
               value: {{ $datafusionThreads | quote }}
             - name: FF_DATAFUSION_MEMORY_LIMIT
               value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
+            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_IO_THREAD_STACK_SIZE
               value: "8MB"
             {{- end }}

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -743,6 +743,10 @@ logfire-remote-mcp:
 #     annotations: {}
 #   # -- Parallelism per pod. Defaults to FusionFire auto-config from effective CPU.
 #   # queryParallelism: 4
+#   # -- DataFusion partitions used by query execution. Defaults to FusionFire's DataFusion thread count.
+#   # datafusionTargetPartitions: 4
+#   # -- Number of rows in each DataFusion execution batch. Defaults to FusionFire's built-in value.
+#   # datafusionBatchSize: 4096
 #   # -- DataFusion memory limit when query-workers are disabled and query-api runs in query-worker mode.
 #   # Defaults to FusionFire auto-config from effective memory.
 #   # datafusionMemory: "4096MB"
@@ -871,7 +875,6 @@ logfire-remote-mcp:
 #     maxReplicas: 6
 #     hpa:
 #       enabled: true
-#       memAverage: 65
 #       cpuAverage: 20
 #     keda:
 #       enabled: true
@@ -1818,6 +1821,7 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
+      datafusionTargetPartitions: 2
       resources:
         requests:
           cpu: "1"
@@ -1924,7 +1928,6 @@ sizingPresets:
         maxReplicas: 24
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 25
     logfire-ff-proxy-cache-byte:
       resources:
@@ -2094,10 +2097,12 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
+      datafusionTargetPartitions: 4
+      datafusionBatchSize: 4096
       resources:
         requests:
           cpu: "2"
-          memory: "4Gi"
+          memory: "8Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2218,7 +2223,6 @@ sizingPresets:
         maxReplicas: 24
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 25
     logfire-ff-proxy-cache-byte:
       resources:
@@ -2457,6 +2461,9 @@ sizingPresets:
             matchLabels:
               app.kubernetes.io/component: logfire-remote-mcp
     logfire-ff-query-api:
+      queryParallelism: 32
+      datafusionTargetPartitions: 4
+      datafusionBatchSize: 4096
       resources:
         requests:
           cpu: "3"
@@ -2599,7 +2606,6 @@ sizingPresets:
         maxReplicas: 24
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 25
       scratchVolume:
         storage: 32Gi


### PR DESCRIPTION
## Summary
Tweak query-api configs on sizing presets
## Upgrade notes
No changes required