### PR TITLE
Add startup probes for chart workloads

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.34-rc.1
+version: 0.13.34-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.34-rc.1](https://img.shields.io/badge/Version-0.13.34--rc.1-informational?style=flat-square) ![AppVersion: 371ca6b7](https://img.shields.io/badge/AppVersion-371ca6b7-informational?style=flat-square)
+![Version: 0.13.34-rc.2](https://img.shields.io/badge/Version-0.13.34--rc.2-informational?style=flat-square) ![AppVersion: 371ca6b7](https://img.shields.io/badge/AppVersion-371ca6b7-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -521,6 +521,7 @@ Before diving deeper, verify these common configuration issues:
 | logfire-redis.podAnnotations | object | `{}` | Pod annotations for the bundled Redis pod. Example:   cluster-autoscaler.kubernetes.io/safe-to-evict: "false" |
 | logfire-redis.readinessProbe | object | `{"initialDelaySeconds":5,"periodSeconds":10,"tcpSocket":{"port":"redis"},"timeoutSeconds":1}` | Redis readiness probe. Override or set to null to disable. |
 | logfire-redis.resources | object | `{}` | Resource requests/limits. Supports the chart shorthand, for example:   cpu: "100m"   memory: "128Mi" or native requests/limits. |
+| logfire-redis.startupProbe | object | `{"failureThreshold":30,"periodSeconds":10,"tcpSocket":{"port":"redis"},"timeoutSeconds":1}` | Redis startup probe. Override or set to null to disable. |
 | logfire-redis.tolerations | list | `[]` | Tolerations for the bundled Redis pod. |
 | logfire-redis.topologySpreadConstraints | list | `[]` | Topology spread constraints for the bundled Redis pod. |
 | logfire-remote-mcp | object | `{"enabled":true}` | Autoscaling & resources for the `logfire-remote-mcp` pod |

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -6,6 +6,33 @@ Helpers specific to Fusionfire workloads and configuration.
 */}}
 
 {{/*
+Give Fusionfire processes enough time to initialize on constrained nodes before
+liveness checks can restart them. The health endpoint is checked immediately so
+fast starts are not delayed by a fixed initial delay.
+*/}}
+{{- define "logfire.ffStartupProbe" -}}
+httpGet:
+  path: /health
+  port: {{ .port }}
+periodSeconds: 10
+timeoutSeconds: 5
+failureThreshold: 30
+{{- end -}}
+
+{{/*
+Readiness can be checked immediately because failures do not restart the
+container. Use /ready so traffic only reaches a fully initialized process.
+*/}}
+{{- define "logfire.ffReadinessProbe" -}}
+httpGet:
+  path: /ready
+  port: {{ .port }}
+periodSeconds: 5
+timeoutSeconds: 5
+failureThreshold: 5
+{{- end -}}
+
+{{/*
 No-preset installs without workload resources still need a synthetic resource
 baseline for FusionFire auto-config, because no Kubernetes resources are
 rendered for the workload.

--- a/charts/logfire/templates/dex/deployment.yaml
+++ b/charts/logfire/templates/dex/deployment.yaml
@@ -115,6 +115,13 @@ spec:
             httpGet:
               path: /healthz/live
               port: telemetry
+          startupProbe:
+            httpGet:
+              path: /healthz/live
+              port: telemetry
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: /healthz/ready

--- a/charts/logfire/templates/logfire-ai-gateway.yaml
+++ b/charts/logfire/templates/logfire-ai-gateway.yaml
@@ -73,6 +73,15 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
             successThreshold: 1
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /health
+              port: {{ $gatewayPort }}
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 3
             httpGet:

--- a/charts/logfire/templates/logfire-backend.yaml
+++ b/charts/logfire/templates/logfire-backend.yaml
@@ -84,7 +84,9 @@ spec:
               path: /health
               port: 8000
             initialDelaySeconds: 15
-            failureThreshold: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 18
           livenessProbe:
             httpGet:
               path: /health/live

--- a/charts/logfire/templates/logfire-ff-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-byte.yaml
@@ -109,11 +109,7 @@ spec:
               path: /health
               port: 9001
           startupProbe:
-            httpGet:
-              path: /health
-              port: 9001
-            failureThreshold: 30
-            periodSeconds: 10
+            {{- include "logfire.ffStartupProbe" (dict "port" 9001) | nindent 12 }}
           lifecycle:
             preStop:
               exec:

--- a/charts/logfire/templates/logfire-ff-compaction-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-compaction-worker.yaml
@@ -81,14 +81,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          startupProbe:
+            {{- include "logfire.ffStartupProbe" (dict "port" 8013) | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8013
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8013) | nindent 12 }}
       volumes:
       {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 6 }}
       {{- include "logfire.inClusterTls.server.volume" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}

--- a/charts/logfire/templates/logfire-ff-crud-api.yaml
+++ b/charts/logfire/templates/logfire-ff-crud-api.yaml
@@ -67,13 +67,9 @@ spec:
               path: /health
               port: 8011
           readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8011
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8011) | nindent 12 }}
           startupProbe:
-              httpGet:
-                path: /health
-                port: 8011
+            {{- include "logfire.ffStartupProbe" (dict "port" 8011) | nindent 12 }}
           lifecycle:
             preStop:
               exec:

--- a/charts/logfire/templates/logfire-ff-ingest-processor.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest-processor.yaml
@@ -112,21 +112,9 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
           readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8012
-            initialDelaySeconds: 0
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8012) | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: /health
-              port: 8012
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 10
-            failureThreshold: 30
+            {{- include "logfire.ffStartupProbe" (dict "port" 8012) | nindent 12 }}
           volumeMounts:
             {{- include "logfire.inClusterTls.caBundle.volumeMount" (dict "ctx" . "mountPath" "/etc/logfire/incluster-ca") | nindent 12 }}
             {{- include "logfire.objectStoreVolumeMounts" . | nindent 12 }}

--- a/charts/logfire/templates/logfire-ff-ingest.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest.yaml
@@ -126,21 +126,9 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 5
           readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8012
-            initialDelaySeconds: 0
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8012) | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: /health
-              port: 8012
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 10
-            failureThreshold: 30
+            {{- include "logfire.ffStartupProbe" (dict "port" 8012) | nindent 12 }}
           volumeMounts:
             - name: {{ include "logfire.ingestVolumeName" . }}
               mountPath: "/fusionfire/ingest-data"

--- a/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
@@ -97,14 +97,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          startupProbe:
+            {{- include "logfire.ffStartupProbe" (dict "port" 8013) | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8013
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8013) | nindent 12 }}
       {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
       volumes:
         {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 8 }}

--- a/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
@@ -83,14 +83,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          startupProbe:
+            {{- include "logfire.ffStartupProbe" (dict "port" 8013) | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8013
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8013) | nindent 12 }}
       volumes:
       {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 6 }}
       {{- include "logfire.inClusterTls.server.volume" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -136,14 +136,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          startupProbe:
+            {{- include "logfire.ffStartupProbe" (dict "port" 8011) | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8011
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8011) | nindent 12 }}
       volumes:
       {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 6 }}
       {{- include "logfire.inClusterTls.server.volume" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -110,14 +110,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5
+          startupProbe:
+            {{- include "logfire.ffStartupProbe" (dict "port" 8011) | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8011
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
+            {{- include "logfire.ffReadinessProbe" (dict "port" 8011) | nindent 12 }}
       volumes:
       {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 6 }}
       {{- include "logfire.inClusterTls.server.volume" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}

--- a/charts/logfire/templates/logfire-frontend-service.yaml
+++ b/charts/logfire/templates/logfire-frontend-service.yaml
@@ -84,6 +84,14 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 8
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/logfire/templates/logfire-remote-mcp.yaml
+++ b/charts/logfire/templates/logfire-remote-mcp.yaml
@@ -77,7 +77,7 @@ spec:
               scheme: HTTP
             periodSeconds: 5
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 3
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/charts/logfire/templates/logfire-service.yaml
+++ b/charts/logfire/templates/logfire-service.yaml
@@ -99,6 +99,9 @@ spec:
             httpGet:
               path: "/stats"
               port: 8181
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
           readinessProbe:
             httpGet:
               path: "/stats"

--- a/charts/logfire/templates/logfire-worker.yaml
+++ b/charts/logfire/templates/logfire-worker.yaml
@@ -53,6 +53,9 @@ spec:
             httpGet:
               path: /health
               port: 8003
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
             failureThreshold: 10
           env:
             - name: MATERIALIZE_DASHBOARDS

--- a/charts/logfire/tests/startup_probe_test.yaml
+++ b/charts/logfire/tests/startup_probe_test.yaml
@@ -1,0 +1,311 @@
+suite: health probes protect workloads during initialization
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+  dev:
+    deployPostgres: true
+tests:
+  - it: gives the backend extra time to initialize
+    templates:
+      - templates/logfire-backend.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 18
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects the Python worker during initialization
+    templates:
+      - templates/logfire-worker.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8003
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 10
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects the frontend during initialization
+    templates:
+      - templates/logfire-frontend-service.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 8
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects Dex during initialization
+    templates:
+      - templates/dex/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /healthz/live
+              port: telemetry
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects HAProxy during initialization
+    templates:
+      - templates/logfire-service.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /stats
+              port: 8181
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects the remote MCP server during initialization
+    templates:
+      - templates/logfire-remote-mcp.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            failureThreshold: 30
+            httpGet:
+              path: /health
+              port: 8005
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects the optional AI gateway during initialization
+    set:
+      logfire-ai-gateway:
+        enabled: true
+    templates:
+      - templates/logfire-ai-gateway.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            failureThreshold: 30
+            httpGet:
+              path: /health
+              port: 8788
+              scheme: HTTP
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: protects bundled Redis during initialization
+    templates:
+      - templates/redis.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            tcpSocket:
+              port: redis
+            failureThreshold: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: uses the standard startup probe for the Fusionfire CRUD API
+    templates:
+      - templates/logfire-ff-crud-api.yaml
+    asserts: &fusionfire_8011_startup_probe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8011
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ready
+              port: 8011
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: uses the standard startup probe for the Fusionfire query API
+    templates:
+      - templates/logfire-ff-query-api.yaml
+    asserts: *fusionfire_8011_startup_probe
+
+  - it: uses the standard startup probe for the optional Fusionfire query worker
+    set:
+      logfire-ff-query-worker:
+        enabled: true
+    templates:
+      - templates/logfire-ff-query-worker.yaml
+    asserts: *fusionfire_8011_startup_probe
+
+  - it: uses the standard startup probe for the Fusionfire compaction worker
+    templates:
+      - templates/logfire-ff-compaction-worker.yaml
+    asserts: &fusionfire_8013_startup_probe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8013
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ready
+              port: 8013
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: uses the standard startup probe for the Fusionfire maintenance scheduler
+    templates:
+      - templates/logfire-ff-maintenance-scheduler.yaml
+    asserts: *fusionfire_8013_startup_probe
+
+  - it: uses the standard startup probe for the Fusionfire maintenance worker
+    templates:
+      - templates/logfire-ff-maintenance-worker.yaml
+    asserts: *fusionfire_8013_startup_probe
+
+  - it: uses the standard startup probe for Fusionfire ingest
+    templates:
+      - templates/logfire-ff-ingest.yaml
+    asserts: &fusionfire_8012_startup_probe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8012
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ready
+              port: 8012
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: uses the standard startup probe for the Fusionfire ingest processor
+    templates:
+      - templates/logfire-ff-ingest-processor.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 8012
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ready
+              port: 8012
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 5
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: uses the standard startup probe for the Fusionfire byte cache
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe
+          value:
+            httpGet:
+              path: /health
+              port: 9001
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+        documentSelector:
+          path: kind
+          value: Deployment

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1462,12 +1462,13 @@ logfire-redis:
     periodSeconds: 10
     timeoutSeconds: 1
 
-  # -- Redis startup probe. Disabled by default.
-  # startupProbe:
-  #   tcpSocket:
-  #     port: redis
-  #   failureThreshold: 30
-  #   periodSeconds: 2
+  # -- Redis startup probe. Override or set to null to disable.
+  startupProbe:
+    tcpSocket:
+      port: redis
+    failureThreshold: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
 
   # -- Persistence for the bundled Redis data directory.
   # This improves recovery across pod restarts but does not make Redis highly available.


### PR DESCRIPTION
## Summary

- Add startup probes to chart-owned workloads so slow initialization does not trigger premature liveness restarts.
- Standardize Fusionfire startup and readiness probes, removing fixed 30-second readiness delays.
- Tune existing backend, worker, HAProxy, and remote MCP startup windows.
- Enable the bundled Redis startup probe by default.

## Upgrade notes

This is a Helm chart pre-release. Install it with `helm install logfire pydantic/logfire --version 0.13.34-rc.2` or pass `--devel`.

When upgrading from `0.13.34-rc.1` or earlier with bundled Redis enabled, Kubernetes replaces the single Redis pod because its probe configuration changed. Expect a brief Redis interruption. Production installations should disable bundled Redis with `logfire-redis.enabled=false` and configure `redisDsn` for managed Redis.