### PR TITLE
Make sizing presets resource-oriented

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.35-rc.1
+version: 0.13.35-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.35-rc.1](https://img.shields.io/badge/Version-0.13.35--rc.1-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
+![Version: 0.13.35-rc.2](https://img.shields.io/badge/Version-0.13.35--rc.2-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.35-rc.1](https://img.shields.io/badge/Version-0.13.35-rc.1-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
+![Version: 0.13.35-rc.1](https://img.shields.io/badge/Version-0.13.35--rc.1-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -289,8 +289,19 @@ sizingPreset: standard
 ```
 
 Use `large` for higher-throughput deployments, `standard` for general production deployments, `small` for lower-traffic deployments that still need ingest and query headroom, or `tiny` for the smallest production footprint.
-Presets apply workload resources, autoscaling, PDBs, best-effort topology spreading for HA-sensitive workloads, and selected FusionFire execution settings.
+Presets apply workload resources, autoscaling, PDBs, and best-effort topology spreading for HA-sensitive workloads. FusionFire derives its execution settings from the effective resources.
 They do not configure environment-specific prerequisites such as hostnames, TLS, PostgreSQL, object storage, image pull secrets, or StorageClasses.
+
+Query API capacity is resource-oriented:
+
+| Preset | CPU request | Memory request | Query cost capacity per pod | Scratch | Replicas |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `tiny` | 1 | 2 GiB | 1 | 1 GiB | 1–6 |
+| `small` | 2 | 4 GiB | 2 | 2 GiB | 1–8 |
+| `standard` | 4 | 8 GiB | 4 | 6 GiB | 3–8 |
+| `large` | 4 | 8 GiB | 4 | 6 GiB | 3–16 |
+
+Query cost capacity defaults to the effective execution-worker CPU rounded up to a whole core. With separate query workers enabled, both the dispatcher and workers derive it from query-worker CPU. Advanced installations can override it with `logfire-ff-query-api.maxQueryCostPerPod`.
 
 The `standard` preset keeps the public request path, query API, and ingest path at a minimum of three replicas.
 The `large` preset inherits `standard` and increases selected FusionFire worker, ingest processor, and byte-cache capacity.
@@ -299,6 +310,7 @@ The `tiny` preset intentionally favors the smallest resource footprint over high
 
 If you do not set a sizing preset or per-workload resources, the chart does not render Kubernetes CPU/memory requests or limits.
 FusionFire still needs internal execution limits, so those derived settings use the `tiny` preset resource baseline without rendering the preset's Kubernetes resources.
+This increases some no-preset FusionFire budgets compared with earlier chart versions. Operators running constrained clusters should select a sizing preset or configure explicit workload resources.
 
 Override individual workloads only after selecting a preset:
 
@@ -312,7 +324,7 @@ logfire-worker:
     ephemeralStorage: "1Gi"
 ```
 
-If `resources.limits` is omitted, this chart defaults limits to the configured requests for Guaranteed QoS.
+Nested `resources.requests` do not add mandatory limits, allowing workloads to use spare node capacity. The legacy flat resource shorthand continues to use the configured values for both requests and limits.
 
 ## Advanced Configuration
 

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -290,8 +290,19 @@ sizingPreset: standard
 ```
 
 Use `large` for higher-throughput deployments, `standard` for general production deployments, `small` for lower-traffic deployments that still need ingest and query headroom, or `tiny` for the smallest production footprint.
-Presets apply workload resources, autoscaling, PDBs, best-effort topology spreading for HA-sensitive workloads, and selected FusionFire execution settings.
+Presets apply workload resources, autoscaling, PDBs, and best-effort topology spreading for HA-sensitive workloads. FusionFire derives its execution settings from the effective resources.
 They do not configure environment-specific prerequisites such as hostnames, TLS, PostgreSQL, object storage, image pull secrets, or StorageClasses.
+
+Query API capacity is resource-oriented:
+
+| Preset | CPU request | Memory request | Query cost capacity per pod | Scratch | Replicas |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `tiny` | 1 | 2 GiB | 1 | 1 GiB | 1–6 |
+| `small` | 2 | 4 GiB | 2 | 2 GiB | 1–8 |
+| `standard` | 4 | 8 GiB | 4 | 6 GiB | 3–8 |
+| `large` | 4 | 8 GiB | 4 | 6 GiB | 3–16 |
+
+Query cost capacity defaults to the effective execution-worker CPU rounded up to a whole core. With separate query workers enabled, both the dispatcher and workers derive it from query-worker CPU. Advanced installations can override it with `logfire-ff-query-api.maxQueryCostPerPod`.
 
 The `standard` preset keeps the public request path, query API, and ingest path at a minimum of three replicas.
 The `large` preset inherits `standard` and increases selected FusionFire worker, ingest processor, and byte-cache capacity.
@@ -300,6 +311,7 @@ The `tiny` preset intentionally favors the smallest resource footprint over high
 
 If you do not set a sizing preset or per-workload resources, the chart does not render Kubernetes CPU/memory requests or limits.
 FusionFire still needs internal execution limits, so those derived settings use the `tiny` preset resource baseline without rendering the preset's Kubernetes resources.
+This increases some no-preset FusionFire budgets compared with earlier chart versions. Operators running constrained clusters should select a sizing preset or configure explicit workload resources.
 
 Override individual workloads only after selecting a preset:
 
@@ -313,7 +325,7 @@ logfire-worker:
     ephemeralStorage: "1Gi"
 ```
 
-If `resources.limits` is omitted, this chart defaults limits to the configured requests for Guaranteed QoS.
+Nested `resources.requests` do not add mandatory limits, allowing workloads to use spare node capacity. The legacy flat resource shorthand continues to use the configured values for both requests and limits.
 
 ## Advanced Configuration
 

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -32,38 +32,6 @@ timeoutSeconds: 5
 failureThreshold: 5
 {{- end -}}
 
-{{/*
-No-preset installs without workload resources still need a synthetic resource
-baseline for FusionFire auto-config, because no Kubernetes resources are
-rendered for the workload.
-*/}}
-{{- define "logfire.ffUseNoPresetResourceFallback" -}}
-{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
-{{- if and (not (.Values.sizingPreset | default "")) (not (get $effectiveServiceValues "resources")) -}}
-true
-{{- end -}}
-{{- end -}}
-
-{{/*
-Conservative resource hints for no-preset/no-resource installs. Keep these
-independent from the sizing presets so preset resource changes do not silently
-increase FusionFire auto-config on installs that render no Kubernetes resources.
-*/}}
-{{- define "logfire.ffNoPresetResourceFallback" -}}
-{{- $fallbacks := dict
-  "logfire-ff-cache-byte" (dict "cpu" "250m" "memory" "384Mi")
-  "logfire-ff-compaction-worker" (dict "cpu" "1" "memory" "2Gi")
-  "logfire-ff-crud-api" (dict "cpu" "100m" "memory" "192Mi")
-  "logfire-ff-ingest" (dict "cpu" "250m" "memory" "512Mi")
-  "logfire-ff-ingest-processor" (dict "cpu" "350m" "memory" "512Mi")
-  "logfire-ff-maintenance-scheduler" (dict "cpu" "100m" "memory" "192Mi")
-  "logfire-ff-maintenance-worker" (dict "cpu" "1" "memory" "512Mi")
-  "logfire-ff-query-api" (dict "cpu" "500m" "memory" "768Mi")
-  "logfire-ff-query-worker" (dict "cpu" "500m" "memory" "768Mi")
--}}
-{{- get $fallbacks .serviceName | default (dict "cpu" "500m" "memory" "1Gi") | toJson -}}
-{{- end -}}
-
 {{- define "logfire.ffCompactionTiersValue" -}}
 {{- $maintenanceWorker := dict "Values" .Values "serviceName" "logfire-ff-maintenance-worker" -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" $maintenanceWorker | fromJson -}}
@@ -127,16 +95,14 @@ overhead. No quota is derived for emptyDir scratch storage.
 
 {{/*
 Expose effective Kubernetes resources to FusionFire so its auto-config formulas
-use the same resources Kubernetes enforces. When no preset/resources are set,
-the chart does not render Kubernetes resources, so use conservative synthetic
-inputs instead.
+use the same resources Kubernetes enforces. Effective resources fall back to
+the tiny preset for internal calculations when no preset/resources are set,
+without rendering Kubernetes resources.
 */}}
 {{- define "logfire.ffResourceEnv" -}}
 {{- $effectiveResources := include "logfire.effectiveResources" . | fromJson -}}
-{{- $useFallback := include "logfire.ffUseNoPresetResourceFallback" . -}}
-{{- $fallbackResources := include "logfire.ffNoPresetResourceFallback" . | fromJson -}}
-{{- $cpu := ternary (get $fallbackResources "cpu") (get $effectiveResources "cpuLimit") (not (empty $useFallback)) -}}
-{{- $memory := ternary (get $fallbackResources "memory") (get $effectiveResources "memoryLimit") (not (empty $useFallback)) -}}
+{{- $cpu := get $effectiveResources "cpuLimit" -}}
+{{- $memory := get $effectiveResources "memoryLimit" -}}
 {{- $cpuMilli := int (include "logfire.cpuMilli" $cpu) -}}
 {{- $memoryMi := int (include "logfire.memoryToMi" $memory) -}}
 - name: FF_RESOURCE_CPU_CORES
@@ -156,11 +122,34 @@ inputs instead.
 {{- end -}}
 
 {{/*
-Resolve query parallelism from explicit service values, falling back to FusionFire auto-config.
+Resolve per-query DataFusion I/O parallelism independently for each service.
 */}}
 {{- define "logfire.ffQueryParallelism" -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
 {{- get $effectiveServiceValues "queryParallelism" | default "auto" -}}
+{{- end -}}
+
+{{/*
+Resolve worker query capacity consistently for the combined query-api deployment
+and optional remote query workers. An explicit query-api override wins.
+Otherwise, derive capacity from the execution worker's effective CPU limit (or
+request when no limit is configured), rounded up to whole cores.
+*/}}
+{{- define "logfire.ffMaxCostPerWorker" -}}
+{{- $queryApiValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" "logfire-ff-query-api") | fromJson -}}
+{{- $queryWorkerEnabled := get (get .Values "logfire-ff-query-worker" | default dict) "enabled" | default false -}}
+{{- $executionServiceName := ternary "logfire-ff-query-worker" "logfire-ff-query-api" $queryWorkerEnabled -}}
+{{- if hasKey $queryApiValues "maxQueryCostPerPod" -}}
+  {{- $override := toString (get $queryApiValues "maxQueryCostPerPod") -}}
+  {{- if not (regexMatch "^[1-9][0-9]*$" $override) -}}
+    {{- fail "logfire-ff-query-api.maxQueryCostPerPod must be a positive integer" -}}
+  {{- end -}}
+  {{- $override -}}
+{{- else -}}
+  {{- $effectiveResources := include "logfire.effectiveResources" (dict "Values" .Values "serviceName" $executionServiceName) | fromJson -}}
+  {{- $cpuMilli := int (include "logfire.cpuMilli" (get $effectiveResources "cpuLimit")) -}}
+  {{- max 1 (div (add $cpuMilli 999) 1000) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -121,7 +121,7 @@ Only sizing and portable availability keys are inherited from presets.
     {{- $presetValues = mergeOverwrite (deepCopy (get $presets "standard")) (deepCopy $presetValues) -}}
   {{- end -}}
   {{- $presetServiceValues := get $presetValues $serviceName | default dict -}}
-  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "queryParallelism" "datafusionThreads" "datafusionTargetPartitions" "datafusionBatchSize" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
+  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "maxQueryCostPerPod" "queryParallelism" "datafusionThreads" "datafusionTargetPartitions" "datafusionBatchSize" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
     {{- if hasKey $presetServiceValues $key -}}
       {{- $_ := set $merged $key (deepCopy (get $presetServiceValues $key)) -}}
     {{- end -}}
@@ -223,9 +223,13 @@ resources:
     {{- end }}
   {{- if $renderLimits }}
   limits:
+    {{- if or $usesFlatResources (hasKey $limits "memory") }}
     memory: {{ $memoryLimit }}
+    {{- end }}
+    {{- if or $usesFlatResources (hasKey $limits "cpu") }}
     cpu: {{ $cpuLimit }}
-    {{- if $ephemeralStorageLimit }}
+    {{- end }}
+    {{- if or (and $usesFlatResources $ephemeralStorageLimit) (hasKey $limits "ephemeral-storage") (hasKey $limits "ephemeralStorage") }}
     ephemeral-storage: {{ $ephemeralStorageLimit }}
     {{- end }}
   {{- end }}

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -1,6 +1,7 @@
 {{- $serviceName := "logfire-ff-query-api" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
 {{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: v1
@@ -88,6 +89,8 @@ spec:
               value: /scratch/fusionfire
             - name: FF_QUERY_PARALLELISM
               value: {{ $queryParallelism | quote }}
+            - name: FF_MAX_COST_PER_WORKER
+              value: {{ $maxCostPerWorker | quote }}
             {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             {{- if not (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
             - name: FF_IO_THREADS

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -1,6 +1,7 @@
 {{- $serviceName := "logfire-ff-query-worker" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
 {{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- if (index .Values $serviceName | default dict).enabled }}
@@ -65,6 +66,8 @@ spec:
               value: /scratch/fusionfire
             - name: FF_QUERY_PARALLELISM
               value: {{ $queryParallelism | quote }}
+            - name: FF_MAX_COST_PER_WORKER
+              value: {{ $maxCostPerWorker | quote }}
             {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
             - name: FF_PG_POOL_MAX_CONNECTIONS
               value: "4"

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -744,8 +744,10 @@ logfire-remote-mcp:
 #   service:
 #     # -- Service annotations
 #     annotations: {}
-#   # -- Parallelism per pod. Defaults to FusionFire auto-config from effective CPU.
-#   # queryParallelism: 4
+#   # -- Maximum query cost per execution pod. Defaults to the effective worker CPU rounded up.
+#   # maxQueryCostPerPod: 4
+#   # -- Per-query DataFusion I/O parallelism. Defaults to FusionFire auto-config from effective CPU.
+#   # queryParallelism: 32
 #   # -- DataFusion partitions used by query execution. Defaults to FusionFire's DataFusion thread count.
 #   # datafusionTargetPartitions: 4
 #   # -- Number of rows in each DataFusion execution batch. Defaults to FusionFire's built-in value.
@@ -756,8 +758,9 @@ logfire-remote-mcp:
 #   # -- Number of replicas
 #   replicas: 2
 #   resources:
-#     cpu: "2"
-#     memory: "8Gi"
+#     requests:
+#       cpu: "2"
+#       memory: "4Gi"
 #   autoscaling:
 #     minReplicas: 2
 #     maxReplicas: 8
@@ -1255,8 +1258,9 @@ logfire-ff-cache-byte:
 #   enabled: true
 #   replicas: 8
 #   resources:
-#     cpu: "500m"
-#     memory: "4Gi"
+#     requests:
+#       cpu: "500m"
+#       memory: "4Gi"
 #   autoscaling:
 #     minReplicas: 8
 #     maxReplicas: 128
@@ -1798,16 +1802,14 @@ sizingPresets:
       resources:
         requests:
           cpu: "750m"
-          memory: "768Mi"
-        limits:
-          cpu: "1"
           memory: "1Gi"
+        limits:
+          memory: "2Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
         hpa:
           enabled: true
-          memAverage: 80
           cpuAverage: 60
       pdb:
         maxUnavailable: 1
@@ -1828,7 +1830,7 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
-      datafusionTargetPartitions: 2
+      datafusionBatchSize: 4096
       resources:
         requests:
           cpu: "1"
@@ -1847,9 +1849,10 @@ sizingPresets:
         storage: "1Gi"
     logfire-ff-query-worker:
       resources:
-        cpu: "500m"
-        memory: "768Mi"
-        ephemeralStorage: "1Gi"
+        requests:
+          cpu: "500m"
+          memory: "768Mi"
+          ephemeral-storage: "1Gi"
       scratchVolume:
         storage: "1Gi"
     logfire-ff-crud-api:
@@ -1885,15 +1888,13 @@ sizingPresets:
           memory: "512Mi"
           ephemeral-storage: "1Gi"
         limits:
-          cpu: "1"
-          memory: "512Mi"
+          memory: "1Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 70
       pdb:
         maxUnavailable: 1
@@ -1920,7 +1921,6 @@ sizingPresets:
         maxReplicas: 4
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 60
       pdb:
         maxUnavailable: 1
@@ -2077,14 +2077,16 @@ sizingPresets:
               app.kubernetes.io/component: logfire-ff-ingest-processor
     logfire-backend:
       resources:
-        cpu: "750m"
-        memory: "1Gi"
+        requests:
+          cpu: "750m"
+          memory: "1Gi"
+        limits:
+          memory: "2Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
         hpa:
           enabled: true
-          memAverage: 75
           cpuAverage: 50
       pdb:
         maxUnavailable: 1
@@ -2105,12 +2107,10 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-query-api:
-      datafusionTargetPartitions: 4
-      datafusionBatchSize: 4096
       resources:
         requests:
           cpu: "2"
-          memory: "8Gi"
+          memory: "4Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
@@ -2125,9 +2125,10 @@ sizingPresets:
         storage: "2Gi"
     logfire-ff-query-worker:
       resources:
-        cpu: "1"
-        memory: "2Gi"
-        ephemeralStorage: "1Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
+          ephemeral-storage: "1Gi"
       scratchVolume:
         storage: "2Gi"
     logfire-ff-crud-api:
@@ -2163,15 +2164,13 @@ sizingPresets:
           memory: "512Mi"
           ephemeral-storage: "1Gi"
         limits:
-          cpu: "1"
-          memory: "512Mi"
+          memory: "1Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 5
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 70
       pdb:
         maxUnavailable: 1
@@ -2203,7 +2202,6 @@ sizingPresets:
         maxReplicas: 6
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 40
       pdb:
         maxUnavailable: 1
@@ -2388,14 +2386,16 @@ sizingPresets:
               app.kubernetes.io/component: logfire-ff-ingest-processor
     logfire-backend:
       resources:
-        cpu: "750m"
-        memory: "1Gi"
+        requests:
+          cpu: "750m"
+          memory: "1Gi"
+        limits:
+          memory: "2Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 6
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 25
       pdb:
         maxUnavailable: 1
@@ -2470,13 +2470,10 @@ sizingPresets:
             matchLabels:
               app.kubernetes.io/component: logfire-remote-mcp
     logfire-ff-query-api:
-      queryParallelism: 32
-      datafusionTargetPartitions: 4
-      datafusionBatchSize: 4096
       resources:
         requests:
-          cpu: "3"
-          memory: "16Gi"
+          cpu: "4"
+          memory: "8Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 3
@@ -2504,9 +2501,10 @@ sizingPresets:
         storage: "6Gi"
     logfire-ff-query-worker:
       resources:
-        cpu: "500m"
-        memory: "4Gi"
-        ephemeralStorage: "1Gi"
+        requests:
+          cpu: "500m"
+          memory: "4Gi"
+          ephemeral-storage: "1Gi"
       scratchVolume:
         storage: "6Gi"
     logfire-ff-crud-api:
@@ -2568,15 +2566,13 @@ sizingPresets:
           memory: "512Mi"
           ephemeral-storage: "1Gi"
         limits:
-          cpu: "1"
-          memory: "512Mi"
+          memory: "1Gi"
           ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 5
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 70
       pdb:
         maxUnavailable: 1
@@ -2589,7 +2585,6 @@ sizingPresets:
         maxReplicas: 6
         hpa:
           enabled: true
-          memAverage: 65
           cpuAverage: 20
       pdb:
         maxUnavailable: 1


### PR DESCRIPTION
## Summary

Make sizing presets resource-oriented by deriving FusionFire query cost capacity from effective CPU, normalizing stable application pod shapes, and using the tiny preset as the canonical internal fallback.

## Upgrade notes

No-preset FusionFire workloads now use the tiny preset baseline and may increase its resources compared with earlier chart versions. Operators running constrained clusters should select a sizing preset or configure explicit workload resources.

### Breaking changes

None.