### PR TITLE
Release chart 0.13.35

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.35-rc.2
+version: 0.13.35
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.35-rc.2](https://img.shields.io/badge/Version-0.13.35--rc.2-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
+![Version: 0.13.35](https://img.shields.io/badge/Version-0.13.35-informational?style=flat-square) ![AppVersion: 4c1b50a6](https://img.shields.io/badge/AppVersion-4c1b50a6-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 


### PR DESCRIPTION
## Summary
- promote chart version `0.13.35-rc.2` to stable `0.13.35`

## Upgrade notes

No-preset FusionFire workloads now use the tiny preset baseline and may increase their resources compared with earlier chart versions. Operators running constrained clusters should select a sizing preset or configure explicit workload resources.

### Breaking changes

None.