### PR TITLE
Release chart 0.13.36

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.36-rc.1
+version: 0.13.36
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -256,6 +256,10 @@ groupOrganizationMapping:
             role: write
 ```
 
+The mapping is authoritative for the organizations and projects it lists and is reconciled when a user signs in. Access in those scopes may be changed or removed; unlisted organizations and projects are left unchanged, and personal organization membership is preserved. When multiple matching groups grant roles in the same scope, the most permissive role is applied.
+
+Setting `groupOrganizationMapping` overrides mappings managed through the public Group Mappings API. The API reports `api_mapping_status: overridden_by_environment`, and update requests return HTTP 409.
+
 ### Object Storage
 
 Logfire requires object storage for data. Supported URI schemes are `s3://`, `gs://`, and `az://`.

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.36-rc.1](https://img.shields.io/badge/Version-0.13.36-rc.1-informational?style=flat-square) ![AppVersion: 358cf2e0](https://img.shields.io/badge/AppVersion-358cf2e0-informational?style=flat-square)
+![Version: 0.13.36](https://img.shields.io/badge/Version-0.13.36-informational?style=flat-square) ![AppVersion: 358cf2e0](https://img.shields.io/badge/AppVersion-358cf2e0-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -257,6 +257,10 @@ groupOrganizationMapping:
             role: write
 ```
 
+The mapping is authoritative for the organizations and projects it lists and is reconciled when a user signs in. Access in those scopes may be changed or removed; unlisted organizations and projects are left unchanged, and personal organization membership is preserved. When multiple matching groups grant roles in the same scope, the most permissive role is applied.
+
+Setting `groupOrganizationMapping` overrides mappings managed through the public Group Mappings API. The API reports `api_mapping_status: overridden_by_environment`, and update requests return HTTP 409.
+
 ### Object Storage
 
 Logfire requires object storage for data. Supported URI schemes are `s3://`, `gs://`, and `az://`.


### PR DESCRIPTION
## Summary
- promote chart version `0.13.36-rc.1` to stable `0.13.36`
- preserve project permissions outside group-mapped project scopes

## Upgrade notes

Group mapping synchronization now preserves project permissions for projects not listed in `groupOrganizationMapping[].organization_roles[].project_roles` or the corresponding public Group Mappings API payload. Only listed projects are managed by the mapping.

When the chart's `groupOrganizationMapping` value is set, it remains authoritative: the public API reports `api_mapping_status: overridden_by_environment`, and updates return HTTP 409.

### Breaking changes

None.