### PR TITLE
Release chart 0.13.37

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.37-rc.1
+version: 0.13.37
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.37-rc.1](https://img.shields.io/badge/Version-0.13.37-rc.1-informational?style=flat-square) ![AppVersion: c4f2def9](https://img.shields.io/badge/AppVersion-c4f2def9-informational?style=flat-square)
+![Version: 0.13.37](https://img.shields.io/badge/Version-0.13.37-informational?style=flat-square) ![AppVersion: c4f2def9](https://img.shields.io/badge/AppVersion-c4f2def9-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 


### PR DESCRIPTION
## Summary

- promote chart version `0.13.37-rc.1` to stable `0.13.37`

## Upgrade notes

No operator action is required. 

### Breaking changes

None.