### PR TITLE
Configure AI gateway Redis and device-token SSO callbacks

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.38
+version: 0.13.39
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.38](https://img.shields.io/badge/Version-0.13.38-informational?style=flat-square) ![AppVersion: c4f2def9](https://img.shields.io/badge/AppVersion-c4f2def9-informational?style=flat-square)
+![Version: 0.13.39](https://img.shields.io/badge/Version-0.13.39-informational?style=flat-square) ![AppVersion: c4f2def9](https://img.shields.io/badge/AppVersion-c4f2def9-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -754,6 +754,7 @@ Create dex configuration secret, merging backend static clients with user provid
 {{- range $url := $logfireUrls -}}
   {{- $redirects = append $redirects (printf "%s/auth/code-callback" $url) -}}
   {{- $redirects = append $redirects (printf "%s/auth/link-provider-code-callback" $url) -}}
+  {{- $redirects = append $redirects (printf "%s/auth/authorize-device-token-sso-callback" $url) -}}
 {{- end -}}
 {{- $_ := set $client "redirectURIs" $redirects -}}
 {{- $_ := set $client "public" false -}}

--- a/charts/logfire/templates/logfire-ai-gateway.yaml
+++ b/charts/logfire/templates/logfire-ai-gateway.yaml
@@ -116,6 +116,8 @@ spec:
                 name: {{ include "logfire.gatewaySecretName" (dict "ctx" . "secretName" "gateway-internal-secret") }}
           - name: GATEWAY_REDIS_DSN
             value: {{ .Values.redisDsn }}
+          - name: SHARED_REDIS_DSN
+            value: {{ .Values.redisDsn }}
           - name: HOST_IP
             valueFrom:
               fieldRef:


### PR DESCRIPTION
## Summary

- configure the AI gateway to use the shared Redis DSN for usage tracking, routing metrics, and OAuth workload-token caching
- register the Dex device-token SSO callback for every configured hostname, fixing the SDK Configure SSO flow

## Upgrade notes

No operator action is required.

### Breaking changes

None.