### PR TITLE
Add client-side byte-cache routing

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40-rc.1
+version: 0.13.40-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.1](https://img.shields.io/badge/Version-0.13.40-rc.1-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
+![Version: 0.13.40-rc.2](https://img.shields.io/badge/Version-0.13.40--rc.2-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -504,7 +504,9 @@ Before diving deeper, verify these common configuration issues:
 | logfire-dex.podAnnotations | object | `{}` | Pod annotations |
 | logfire-dex.podLabels | object | `{}` | Pod labels |
 | logfire-dex.service.annotations | object | `{}` | Service annotations |
-| logfire-ff-cache-byte | object | `{"pdb":{},"replicas":3,"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
+| logfire-ff-cache-byte | object | `{"clientSideRouting":{"enabled":true,"zoneAware":false},"pdb":{},"replicas":3,"scratchVolume":{"storage":"32Gi"}}` | Autoscaling & resources for the byte cache pods |
+| logfire-ff-cache-byte.clientSideRouting.enabled | bool | `true` | Route query byte-cache requests directly using EndpointSlice discovery. HAProxy remains for unmigrated consumers; stale zoneless discovery can use ClusterIP. |
+| logfire-ff-cache-byte.clientSideRouting.zoneAware | bool | `false` | Restrict direct routing to zone-local cache pods. Requires nodes/get cluster RBAC and adds soft zone/hostname spreading. Cache replicas must cover every query zone; local misses use durable storage. |
 | logfire-ff-cache-byte.replicas | int | `3` | Number of byte-cache replicas when autoscaling is not configured. |
 | logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume |
 | logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"16Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -6,6 +6,30 @@ Helpers specific to Fusionfire workloads and configuration.
 */}}
 
 {{/*
+Configure query workloads to discover byte-cache pods directly. Keep these
+defaults before service-specific env so operators can explicitly override them.
+*/}}
+{{- define "logfire.ffByteCacheClientRoutingEnv" -}}
+{{- $routing := get (get .Values "logfire-ff-cache-byte" | default dict) "clientSideRouting" | default dict -}}
+{{- if get $routing "enabled" }}
+- name: FF_BYTE_CACHE_K8S_SERVICE
+  value: logfire-ff-cache-byte-internal
+- name: FF_BYTE_CACHE_K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: FF_BYTE_CACHE_K8S_PORT_NAME
+  value: {{ ternary "https" "http" .Values.inClusterTls.enabled }}
+{{- if get $routing "zoneAware" }}
+- name: FF_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Give Fusionfire processes enough time to initialize on constrained nodes before
 liveness checks can restart them. The health endpoint is checked immediately so
 fast starts are not delayed by a fixed initial delay.

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1076,12 +1076,30 @@ default-checksum
 {{- end -}}
 {{- end -}}
 
+{{/*
+Render global and service-level pod scheduling. Optional default topology spread
+constraints are appended only when the merged user/preset list does not already
+contain the same topologyKey.
+*/}}
 {{- define "logfire.podScheduling" -}}
 {{- $serviceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
 {{- $nodeSelector := merge (deepCopy ($serviceValues.nodeSelector | default dict)) (.Values.nodeSelector | default dict) -}}
 {{- $affinity := merge (deepCopy ($serviceValues.affinity | default dict)) (.Values.affinity | default dict) -}}
 {{- $tolerations := concat ($serviceValues.tolerations | default list) (.Values.tolerations | default list) -}}
 {{- $topologySpreadConstraints := concat ($serviceValues.topologySpreadConstraints | default list) (.Values.topologySpreadConstraints | default list) -}}
+{{- range (.defaultTopologySpreadConstraints | default list) -}}
+  {{- $defaultConstraint := . -}}
+  {{- $topologyKey := get $defaultConstraint "topologyKey" -}}
+  {{- $hasTopologyKey := false -}}
+  {{- range $topologySpreadConstraints -}}
+    {{- if eq (get . "topologyKey") $topologyKey -}}
+      {{- $hasTopologyKey = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $hasTopologyKey -}}
+    {{- $topologySpreadConstraints = append $topologySpreadConstraints $defaultConstraint -}}
+  {{- end -}}
+{{- end -}}
 {{- $blocks := list -}}
 {{- if $nodeSelector -}}
 {{- $blocks = append $blocks (printf "nodeSelector:%s" (toYaml $nodeSelector | nindent 2 | trimSuffix "\n")) -}}

--- a/charts/logfire/templates/logfire-ff-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-byte.yaml
@@ -1,5 +1,14 @@
 {{- $serviceName := "logfire-ff-cache-byte" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
+{{- $routing := get (get .Values $serviceName | default dict) "clientSideRouting" | default dict -}}
+{{- $routingTopologySpreadConstraints := list -}}
+{{- if and (get $routing "enabled") (get $routing "zoneAware") -}}
+  {{- $selector := dict "matchLabels" (dict "app.kubernetes.io/component" $serviceName) -}}
+  {{- $routingTopologySpreadConstraints = list
+    (dict "maxSkew" 1 "topologyKey" "topology.kubernetes.io/zone" "whenUnsatisfiable" "ScheduleAnyway" "labelSelector" $selector)
+    (dict "maxSkew" 1 "topologyKey" "kubernetes.io/hostname" "whenUnsatisfiable" "ScheduleAnyway" "labelSelector" $selector)
+  -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: Service
@@ -62,7 +71,7 @@ spec:
       {{- end }}
       {{- include "logfire.initContainers" (dict "ctx" . "serviceName" $serviceName) | nindent 6}}
       {{- include "logfire.securityContext" .Values.podSecurityContext | nindent 6 }}
-      {{- include "logfire.podScheduling" (dict "Values" .Values "serviceName" $serviceName) | nindent 6}}
+      {{- include "logfire.podScheduling" (dict "Values" .Values "serviceName" $serviceName "defaultTopologySpreadConstraints" $routingTopologySpreadConstraints) | nindent 6}}
       containers:
         - name: {{ $serviceName }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.fusionfireImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $serviceName "Chart" .Chart) }}'

--- a/charts/logfire/templates/logfire-ff-cache-routing-rbac.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-routing-rbac.yaml
@@ -1,0 +1,61 @@
+{{- $routing := get (get .Values "logfire-ff-cache-byte" | default dict) "clientSideRouting" | default dict -}}
+{{- if get $routing "enabled" }}
+{{- $identity := printf "%s-%s-ff-cache-routing" (include "logfire.fullname" .) .Release.Namespace -}}
+{{- $releaseIdentity := printf "%s/%s" .Release.Namespace .Release.Name -}}
+{{- $nameHash := sha256sum $releaseIdentity | trunc 8 -}}
+{{- $namePrefix := $identity | trunc 54 | trimSuffix "-" -}}
+{{- $name := printf "%s-%s" $namePrefix $nameHash -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "logfire.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if get $routing "zoneAware" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "logfire.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -122,6 +122,7 @@ spec:
                   name: {{ include "logfire.postgresSecretName" . }}
                   key: postgresDsn
             {{- include "logfire.objectStoreEnv" . | nindent 12 -}}
+            {{- include "logfire.ffByteCacheClientRoutingEnv" . | nindent 12 }}
             {{- with (index .Values $serviceName | default dict).env }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -96,6 +96,7 @@ spec:
                   name: {{ include "logfire.postgresSecretName" . }}
                   key: postgresDsn
             {{- include "logfire.objectStoreEnv" . | nindent 12 -}}
+            {{- include "logfire.ffByteCacheClientRoutingEnv" . | nindent 12 }}
             {{- with (index .Values $serviceName | default dict).env }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/logfire/templates/logfire-service-config.yaml
+++ b/charts/logfire/templates/logfire-service-config.yaml
@@ -140,7 +140,7 @@ stringData:
       option httpchk GET /health
       http-check expect status 200
       timeout connect 3s
-      timeout server 50s
+      timeout server 120s
 
       {{- $queryApiSni := printf "logfire-ff-query-api.%s.svc.%s" .Release.Namespace (.Values.clusterDomain | default "cluster.local") -}}
       {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}

--- a/charts/logfire/tests/cache_routing_test.yaml
+++ b/charts/logfire/tests/cache_routing_test.yaml
@@ -1,0 +1,270 @@
+suite: byte-cache client-side routing
+release:
+  name: lf
+  namespace: cache-ns
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+  dev:
+    deployPostgres: true
+tests:
+  - it: configures zoneless query API routing by default before user env overrides
+    set:
+      logfire-ff-query-api:
+        env:
+          - name: FF_BYTE_CACHE_K8S_PORT_NAME
+            value: custom
+    templates:
+      - templates/logfire-ff-query-api.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_BYTE_CACHE_K8S_SERVICE
+            value: logfire-ff-cache-byte-internal
+        documentSelector:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_BYTE_CACHE_K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        documentSelector:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_BYTE_CACHE_K8S_PORT_NAME
+            value: http
+        documentSelector:
+          path: kind
+          value: Deployment
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_NODE_NAME
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].env[-1]
+          value:
+            name: FF_BYTE_CACHE_K8S_PORT_NAME
+            value: custom
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: configures zone-aware HTTPS routing on query workers
+    set:
+      logfire-ff-query-worker:
+        enabled: true
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          zoneAware: true
+      inClusterTls:
+        enabled: true
+        caBundle:
+          existingConfigMap:
+            name: logfire-incluster-ca
+    templates:
+      - templates/logfire-ff-query-worker.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_BYTE_CACHE_K8S_PORT_NAME
+            value: https
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+
+  - it: omits query routing environment when disabled
+    set:
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          enabled: false
+          zoneAware: true
+    templates:
+      - templates/logfire-ff-query-api.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_BYTE_CACHE_K8S_SERVICE
+            value: logfire-ff-cache-byte-internal
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: grants only EndpointSlice discovery by default
+    templates:
+      - templates/logfire-ff-cache-routing-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: lf-logfire-cache-ns-ff-cache-routing-f5f9750e
+        documentSelector:
+          path: kind
+          value: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+        documentSelector:
+          path: kind
+          value: Role
+      - equal:
+          path: subjects[0]
+          value:
+            kind: ServiceAccount
+            name: default
+            namespace: cache-ns
+        documentSelector:
+          path: kind
+          value: RoleBinding
+
+  - it: grants node lookup when zone awareness is enabled
+    set:
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          zoneAware: true
+    templates:
+      - templates/logfire-ff-cache-routing-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 4
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - nodes
+            verbs:
+              - get
+        documentSelector:
+          path: kind
+          value: ClusterRole
+      - equal:
+          path: subjects[0]
+          value:
+            kind: ServiceAccount
+            name: default
+            namespace: cache-ns
+        documentSelector:
+          path: kind
+          value: ClusterRoleBinding
+
+  - it: omits routing RBAC when client routing is disabled
+    set:
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          enabled: false
+          zoneAware: true
+    templates:
+      - templates/logfire-ff-cache-routing-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not add cache spreading without zone awareness
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: adds soft zone and hostname cache spreading when zone awareness is enabled
+    set:
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          zoneAware: true
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: logfire-ff-cache-byte
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: logfire-ff-cache-byte
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: preserves user cache constraints without duplicating the zone spread
+    set:
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          zoneAware: true
+        topologySpreadConstraints:
+          - maxSkew: 2
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: logfire-ff-cache-byte
+          - maxSkew: 1
+            topologyKey: example.com/rack
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: logfire-ff-cache-byte
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - maxSkew: 2
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: logfire-ff-cache-byte
+            - maxSkew: 1
+              topologyKey: example.com/rack
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: logfire-ff-cache-byte
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: logfire-ff-cache-byte
+        documentSelector:
+          path: kind
+          value: Deployment

--- a/charts/logfire/tests/service_config_test.yaml
+++ b/charts/logfire/tests/service_config_test.yaml
@@ -15,6 +15,9 @@ tests:
       - matchRegex:
           path: stringData["haproxy.cfg"]
           pattern: "use_backend logfire-ff-query-api if path_query_v2"
+      - matchRegex:
+          path: stringData["haproxy.cfg"]
+          pattern: "backend logfire-ff-query-api\\n  balance roundrobin\\n  option httpchk GET /health\\n  http-check expect status 200\\n  timeout connect 3s\\n  timeout server 120s"
 
   - it: routes /v1/(traces|metrics|logs) to the ingest backend
     set:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -901,6 +901,14 @@ logfire-remote-mcp:
 
 # -- Autoscaling & resources for the byte cache pods
 logfire-ff-cache-byte:
+  clientSideRouting:
+    # -- Route query byte-cache requests directly using EndpointSlice discovery.
+    # HAProxy remains for unmigrated consumers; stale zoneless discovery can use ClusterIP.
+    enabled: true
+    # -- Restrict direct routing to zone-local cache pods.
+    # Requires nodes/get cluster RBAC and adds soft zone/hostname spreading.
+    # Cache replicas must cover every query zone; local misses use durable storage.
+    zoneAware: false
 #   # -- Workload labels
 #   labels: {}
 #   # -- Workload annotations


### PR DESCRIPTION
## Summary

- enable zoneless EndpointSlice-based byte-cache routing by default
- add opt-in zone awareness with Node RBAC and soft cache spreading
- keep HAProxy deployed for unmigrated consumers
- use namespace-qualified, hash-suffixed RBAC names
- raise the direct `/v2/query` timeout from 50s to 120s
- bump the chart pre-release to `0.13.40-rc.2`

## Routing behavior

| Configuration | Routing | RBAC | Cache spreading |
|---|---|---|---|
| `enabled: false` | HAProxy | None | None |
| `enabled: true`, `zoneAware: false` | Direct, zoneless | EndpointSlice Role | None |
| `enabled: true`, `zoneAware: true` | Direct, zone-local | EndpointSlice Role + Node ClusterRole | Zone + hostname |

```yaml
logfire-ff-cache-byte:
  clientSideRouting:
    enabled: true
    zoneAware: false
```

Zone-aware installations need at least as many cache replicas as query zones. Generated spreads are soft, preserve user constraints, and avoid duplicate topology keys.

HAProxy remains for unmigrated consumers. Stale zoneless discovery can use the existing ClusterIP fallback; zone-local misses fall through to durable storage.

### Breaking changes

None.

## Testing

- `helm unittest charts/logfire` (43 tests)
- `helm lint charts/logfire --values charts/logfire/ci/ci-values.yaml`
- `ct lint --config ci/ct.yaml --target-branch main`