### PR TITLE
Include fusionfire-crud-api settings for remote mcp

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40-rc.2
+version: 0.13.40-rc.3
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.2](https://img.shields.io/badge/Version-0.13.40--rc.2-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
+![Version: 0.13.40-rc.3](https://img.shields.io/badge/Version-0.13.40--rc.3-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/logfire-remote-mcp.yaml
+++ b/charts/logfire/templates/logfire-remote-mcp.yaml
@@ -138,6 +138,10 @@ spec:
             value: "{{ include "logfire.scheme" . }}://logfire-ff-query-api"
           - name: FUSIONFIRE_QUERY_PORT
             value: "{{ include "logfire.port" (dict "port" 8011 "root" .) }}"
+          - name: FUSIONFIRE_CRUD_HOST
+            value: "{{ include "logfire.scheme" . }}://logfire-ff-crud-api"
+          - name: FUSIONFIRE_CRUD_PORT
+            value: "{{ include "logfire.port" (dict "port" 8011 "root" .) }}"
           - name: LOGFIRE_REGION
             value: {{ .Values.logfireRegion | default "local" }}
           - name: ALLOWED_HOSTS


### PR DESCRIPTION
## Summary

This includes a couple of environment vars to ensure that the MCP server has appropriate access to the fusionfire crud api endpoint for use in some changes to materialized views.

## Upgrade notes
<!-- If an operator needs to do anything special after upgrading (values changes, migrations, restarts), describe it here. -->
### Breaking changes
<!-- If this is a breaking change, describe what breaks and how to migrate. -->
