### PR TITLE
Set byte-cache disk capacity from scratch volume size

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40-rc.3
+version: 0.13.40-rc.4
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.3](https://img.shields.io/badge/Version-0.13.40--rc.3-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
+![Version: 0.13.40-rc.4](https://img.shields.io/badge/Version-0.13.40--rc.4-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -508,7 +508,7 @@ Before diving deeper, verify these common configuration issues:
 | logfire-ff-cache-byte.clientSideRouting.enabled | bool | `true` | Route query byte-cache requests directly using EndpointSlice discovery. HAProxy remains for unmigrated consumers; stale zoneless discovery can use ClusterIP. |
 | logfire-ff-cache-byte.clientSideRouting.zoneAware | bool | `false` | Restrict direct routing to zone-local cache pods. Requires nodes/get cluster RBAC and adds soft zone/hostname spreading. Cache replicas must cover every query zone; local misses use durable storage. |
 | logfire-ff-cache-byte.replicas | int | `3` | Number of byte-cache replicas when autoscaling is not configured. |
-| logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume |
+| logfire-ff-cache-byte.scratchVolume | object | `{"storage":"32Gi"}` | Cache byte ephemeral volume. storage accepts Kubernetes quantities (e.g. 32Gi, 1.5Gi, 10G) of at least 1Mi. |
 | logfire-ff-ingest | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}},"volumeClaimTemplates":{"storage":"16Gi"}}` | Autoscaling & resources for the `logfire-ff-ingest` pod |
 | logfire-ff-ingest-processor | object | `{"annotations":{},"env":[{"name":"RUST_LOG","value":"warn"}],"labels":{},"podAnnotations":{},"podLabels":{},"service":{"annotations":{}}}` | Autoscaling & resources for the `logfire-ff-ingest-processor` pod |
 | logfire-ff-ingest-processor.annotations | object | `{}` | Workload annotations |

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -80,22 +80,19 @@ failureThreshold: 5
 {{- end -}}
 
 {{/*
-Convert storage quantities used by scratchVolume.storage to whole GiB.
+Convert storage quantities used by scratchVolume.storage to whole MiB via the
+shared Kubernetes quantity parser (case-sensitive: decimal suffixes like G are
+powers of 1000, binary suffixes like Gi are powers of 1024), rounding down so
+derived sizes never exceed the volume. Quantities below 1Mi fail rather than
+rounding to zero.
 */}}
-{{- define "logfire.storageQuantityToGi" -}}
-{{- $quantity := required "logfire.storageQuantityToGi: storage quantity is required" . | toString | trim -}}
-{{- $unit := regexFind "[a-zA-Z]+$" $quantity | lower -}}
-{{- $valueText := regexReplaceAll "[a-zA-Z]+$" $quantity "" | trim -}}
-{{- $value := int $valueText -}}
-{{- if or (eq $unit "gi") (eq $unit "g") (eq $unit "gb") -}}
-{{- $value -}}
-{{- else if or (eq $unit "ti") (eq $unit "t") (eq $unit "tb") -}}
-{{- mul $value 1024 -}}
-{{- else if or (eq $unit "mi") (eq $unit "m") (eq $unit "mb") -}}
-{{- max 1 (div (add $value 1023) 1024) -}}
-{{- else -}}
-{{- fail (printf "unsupported scratchVolume.storage quantity %q; use Mi, Gi, or Ti" $quantity) -}}
+{{- define "logfire.storageQuantityToMi" -}}
+{{- $quantity := required "logfire.storageQuantityToMi: storage quantity is required" . | toString | trim -}}
+{{- $miInt := int (include "logfire.memoryToMi" $quantity) -}}
+{{- if lt $miInt 1 -}}
+{{- fail (printf "scratchVolume.storage %q is below the 1Mi minimum" $quantity) -}}
 {{- end -}}
+{{- $miInt -}}
 {{- end -}}
 
 {{/*
@@ -111,8 +108,27 @@ overhead. No quota is derived for emptyDir scratch storage.
 {{- else -}}
 {{- $scratchVolume := get $effectiveServiceValues "scratchVolume" | default dict -}}
 {{- with (get $scratchVolume "storage") -}}
-{{- $storageGi := int (include "logfire.storageQuantityToGi" .) -}}
-{{- printf "%dGB" (max 1 (div $storageGi 2)) -}}
+{{- $storageMi := int (include "logfire.storageQuantityToMi" .) -}}
+{{- printf "%dMB" (max 1 (div $storageMi 2)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Byte-cache disk capacity. Explicit cacheDiskCapacity wins; otherwise 80% of
+the scratch volume size. Sized from the declared volume, not the filesystem:
+network filesystems can report effectively unlimited free space, and
+free-space sizing then OOMs the pod at startup. Not derived for emptyDir.
+*/}}
+{{- define "logfire.ffCacheDiskCapacity" -}}
+{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
+{{- with (get $effectiveServiceValues "cacheDiskCapacity") -}}
+{{- . -}}
+{{- else -}}
+{{- $scratchVolume := get $effectiveServiceValues "scratchVolume" | default dict -}}
+{{- with (get $scratchVolume "storage") -}}
+{{- $storageMi := int (include "logfire.storageQuantityToMi" .) -}}
+{{- printf "%dMB" (max 1 (div (mul $storageMi 4) 5)) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/logfire/templates/_helpers-resources.tpl
+++ b/charts/logfire/templates/_helpers-resources.tpl
@@ -64,7 +64,7 @@ Supports common binary and decimal suffixes plus plain bytes.
 {{- $memory := trim (toString .) -}}
 {{- $pattern := "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?([EPTGMK]i?|[numkKMGTEP])?$" -}}
 {{- if not (regexMatch $pattern $memory) -}}
-  {{- fail (printf "Invalid memory format '%s'. Use Kubernetes quantity format (e.g., '1536Mi', '1.5Gi', '2G')." $memory) -}}
+  {{- fail (printf "Invalid quantity format '%s'. Use Kubernetes quantity format (e.g., '1536Mi', '1.5Gi', '2G')." $memory) -}}
 {{- end -}}
 {{- $number := regexFind "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?" $memory -}}
 {{- $unit := regexReplaceAll "^[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?" $memory "" -}}
@@ -103,7 +103,7 @@ Supports common binary and decimal suffixes plus plain bytes.
 {{- else if eq $unit "E" -}}
   {{- $mi = divf (mulf $value 1000000000000000000.0) 1048576.0 -}}
 {{- else -}}
-  {{- fail (printf "Invalid memory format '%s'." $memory) -}}
+  {{- fail (printf "Invalid quantity format '%s'." $memory) -}}
 {{- end -}}
 {{- int (floor $mi) -}}
 {{- end -}}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -121,7 +121,7 @@ Only sizing and portable availability keys are inherited from presets.
     {{- $presetValues = mergeOverwrite (deepCopy (get $presets "standard")) (deepCopy $presetValues) -}}
   {{- end -}}
   {{- $presetServiceValues := get $presetValues $serviceName | default dict -}}
-  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "maxQueryCostPerPod" "queryParallelism" "datafusionThreads" "datafusionTargetPartitions" "datafusionBatchSize" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
+  {{- range $key := list "resources" "autoscaling" "pdb" "replicas" "maxQueryCostPerPod" "queryParallelism" "datafusionThreads" "datafusionTargetPartitions" "datafusionBatchSize" "ioThreads" "datafusionMemory" "maintenanceRecordBatchMemory" "spillToDiskQuota" "cacheDiskCapacity" "scratchVolume" "volumeClaimTemplates" "jobParallelism" "cpuConcurrency" "parquetSpoolThresholdBytes" "maxCompactionJobSizeBytes" "directFileBufferMaxBytes" "directFileSubmitConcurrency" "topologySpreadConstraints" -}}
     {{- if hasKey $presetServiceValues $key -}}
       {{- $_ := set $merged $key (deepCopy (get $presetServiceValues $key)) -}}
     {{- end -}}

--- a/charts/logfire/templates/logfire-ff-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-byte.yaml
@@ -96,6 +96,10 @@ spec:
               value: "0.05"
             - name: FF_CACHE_LOCAL_DIR
               value: /scratch
+            {{- with (include "logfire.ffCacheDiskCapacity" (dict "Values" .Values "serviceName" $serviceName)) }}
+            - name: FF_CACHE_DISK_CAPACITY
+              value: {{ . | quote }}
+            {{- end }}
             {{- with (index .Values $serviceName | default dict).env }}
               {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/logfire/tests/cache_routing_test.yaml
+++ b/charts/logfire/tests/cache_routing_test.yaml
@@ -268,3 +268,127 @@ tests:
         documentSelector:
           path: kind
           value: Deployment
+
+  - it: derives disk-cache capacity from the scratch volume claim size
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "26214MB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: scales derived disk-cache capacity with a custom scratch volume size
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume:
+          storage: 10Gi
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "8192MB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: keeps derived disk-cache capacity below sub-GiB scratch volumes
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume:
+          storage: 500Mi
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "400MB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: lets explicit cacheDiskCapacity override the derived value
+    set:
+      logfire-ff-cache-byte:
+        cacheDiskCapacity: "24GB"
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "24GB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: omits disk-cache capacity for emptyDir scratch storage
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume: null
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+          any: true
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: derives disk-cache capacity from fractional scratch volume quantities
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume:
+          storage: 1.5Gi
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "1228MB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: treats decimal storage suffixes as powers of 1000
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume:
+          storage: 1G
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_CACHE_DISK_CAPACITY
+            value: "762MB"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: rejects scratch volume quantities below 1Mi
+    set:
+      logfire-ff-cache-byte:
+        scratchVolume:
+          storage: 512Ki
+    templates:
+      - templates/logfire-ff-cache-byte.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: 'scratchVolume.storage "512Ki" is below the 1Mi minimum'

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -943,13 +943,17 @@ logfire-ff-cache-byte:
 #   pdb:
 #     maxUnavailable: 1
   pdb: {}
-  # -- Cache byte ephemeral volume
+  # -- Cache byte ephemeral volume. storage accepts Kubernetes quantities (e.g. 32Gi, 1.5Gi, 10G) of at least 1Mi.
   scratchVolume:
     storage: 32Gi
     #  storageClassName: my-storage-class
 
 #     labels:
 #       type: my-volume
+
+#   # -- Disk-cache capacity. Defaults to 80% of scratchVolume.storage.
+#   # Ignored by image tags older than de12a70b, which size from free space.
+#   cacheDiskCapacity: "24GB"
 
 
 # -- Autoscaling & resources for the byte proxy cache pods
@@ -1055,6 +1059,7 @@ logfire-ff-cache-byte:
 #   pdb:
 #     maxUnavailable: 1
 #     minAvailable: 1
+#   # -- Ephemeral scratch volume. storage accepts Kubernetes quantities (e.g. 32Gi, 1.5Gi, 10G) of at least 1Mi.
 #   scratchVolume:
 #     storageClassName: my-storage-class
 #     storage: 1Gi
@@ -1124,6 +1129,7 @@ logfire-ff-cache-byte:
 #   pdb:
 #     maxUnavailable: 1
 #     minAvailable: 1
+#   # -- Ephemeral scratch volume. storage accepts Kubernetes quantities (e.g. 32Gi, 1.5Gi, 10G) of at least 1Mi.
 #   scratchVolume:
 #     storageClassName: my-storage-class
 #     storage: 1Gi


### PR DESCRIPTION
## Summary
The byte cache now bounds its disk cache to 80% of its scratch volume size instead of trusting the filesystem's reported free space, fixing startup OOM crash loops on storage classes that report effectively unlimited free space (e.g. EFS).

## Upgrade notes
No action required for standard installs. The derived capacity matches the previous behavior on correctly-sized block volumes. To set a different bound, use `logfire-ff-cache-byte.cacheDiskCapacity` (e.g. `"24GB"`). Requires appVersion `de12a70b` or later; older images ignore the setting.

Related fixes in the same derivation path:
- `scratchVolume.storage` now accepts Ki/Mi/Gi/Ti quantities including fractions (e.g. `1.5Gi`), converted exactly and rounded down to whole Mi; fractional values previously mis-parsed to tiny sizes. Quantities below 1Mi fail rendering with a clear error.
- The derived DataFusion spill quota is computed in MiB, so sub-GiB scratch volumes no longer get a quota exceeding the volume. Rendered values change form (`32GB` → `32768MB`) but are numerically identical for all preset sizes except `dev`, where the 1Gi scratch quota corrects from `1GB` to `512MB`.

### Breaking changes
None.