### PR TITLE
Configure Gateway ingest endpoint

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -3,7 +3,7 @@ version: 0.13.40-rc.5
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 
-appVersion: "de12a70b"
+appVersion: "4ae3e48d"
 
 dependencies:
   - name: postgresql

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40-rc.4
+version: 0.13.40-rc.5
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.5](https://img.shields.io/badge/Version-0.13.40--rc.5-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
+![Version: 0.13.40-rc.5](https://img.shields.io/badge/Version-0.13.40--rc.5-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.4](https://img.shields.io/badge/Version-0.13.40--rc.4-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
+![Version: 0.13.40-rc.5](https://img.shields.io/badge/Version-0.13.40--rc.5-informational?style=flat-square) ![AppVersion: de12a70b](https://img.shields.io/badge/AppVersion-de12a70b-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/logfire-ai-gateway.yaml
+++ b/charts/logfire/templates/logfire-ai-gateway.yaml
@@ -127,7 +127,7 @@ spec:
             value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $serviceName) | quote }}
           - name: LOGFIRE_BASE_URL
             value: http://logfire-otel-collector:4318
-          - name: GATEWAY_PROJECT_OTEL_BASE_URL
+          - name: GATEWAY_INGEST_BASE_URL
             value: "{{ include "logfire.scheme" . }}://logfire-ff-ingest:{{ include "logfire.port" (dict "port" 8012 "root" .) }}"
           - name: ON_PREM
             value: "true"

--- a/charts/logfire/templates/logfire-ai-gateway.yaml
+++ b/charts/logfire/templates/logfire-ai-gateway.yaml
@@ -127,6 +127,8 @@ spec:
             value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $serviceName) | quote }}
           - name: LOGFIRE_BASE_URL
             value: http://logfire-otel-collector:4318
+          - name: GATEWAY_PROJECT_OTEL_BASE_URL
+            value: "{{ include "logfire.scheme" . }}://logfire-ff-ingest:{{ include "logfire.port" (dict "port" 8012 "root" .) }}"
           - name: ON_PREM
             value: "true"
           - name: LOGFIRE_SERVICE_NAME

--- a/charts/logfire/templates/logfire-ai-gateway.yaml
+++ b/charts/logfire/templates/logfire-ai-gateway.yaml
@@ -147,6 +147,8 @@ spec:
           {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
           - name: IN_CLUSTER_CA_BUNDLE_PATH
             value: /etc/logfire/incluster-ca/ca.crt
+          - name: NODE_EXTRA_CA_CERTS
+            value: /etc/logfire/incluster-ca/ca.crt
           - name: HTTPS_PORT
             value: "{{ .Values.inClusterTls.httpsPort }}"
           - name: TLS_CERT_PATH

--- a/charts/logfire/templates/logfire-worker.yaml
+++ b/charts/logfire/templates/logfire-worker.yaml
@@ -86,6 +86,10 @@ spec:
               value: "{{ include "logfire.scheme" . }}://logfire-ff-query-api"
             - name: FUSIONFIRE_QUERY_PORT
               value: "{{ include "logfire.port" (dict "port" 8011 "root" .) }}"
+            - name: FUSIONFIRE_INGEST_HOST
+              value: "{{ include "logfire.scheme" . }}://logfire-ff-ingest-processor"
+            - name: FUSIONFIRE_INGEST_PORT
+              value: "{{ include "logfire.port" (dict "port" 8012 "root" .) }}"
             - name: FUSIONFIRE_CRUD_HOST
               value: "{{ include "logfire.scheme" . }}://logfire-ff-crud-api"
             - name: FUSIONFIRE_CRUD_PORT

--- a/charts/logfire/tests/feature_toggle_test.yaml
+++ b/charts/logfire/tests/feature_toggle_test.yaml
@@ -55,6 +55,14 @@ tests:
         documentSelector:
           path: kind
           value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_EXTRA_CA_CERTS
+            value: /etc/logfire/incluster-ca/ca.crt
+        documentSelector:
+          path: kind
+          value: Deployment
 
   - it: ai gateway Deployment is absent when disabled
     set:

--- a/charts/logfire/tests/feature_toggle_test.yaml
+++ b/charts/logfire/tests/feature_toggle_test.yaml
@@ -26,6 +26,35 @@ tests:
           apiVersion: v1
           name: logfire-ai-gateway
           any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GATEWAY_PROJECT_OTEL_BASE_URL
+            value: http://logfire-ff-ingest:8012
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: ai gateway uses the in-cluster TLS ingest endpoint
+    set:
+      logfire-ai-gateway:
+        enabled: true
+      inClusterTls:
+        enabled: true
+        caBundle:
+          existingConfigMap:
+            name: logfire-incluster-ca
+    templates:
+      - templates/logfire-ai-gateway.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GATEWAY_PROJECT_OTEL_BASE_URL
+            value: https://logfire-ff-ingest:8443
+        documentSelector:
+          path: kind
+          value: Deployment
 
   - it: ai gateway Deployment is absent when disabled
     set:

--- a/charts/logfire/tests/feature_toggle_test.yaml
+++ b/charts/logfire/tests/feature_toggle_test.yaml
@@ -29,7 +29,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: GATEWAY_PROJECT_OTEL_BASE_URL
+            name: GATEWAY_INGEST_BASE_URL
             value: http://logfire-ff-ingest:8012
         documentSelector:
           path: kind
@@ -50,7 +50,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: GATEWAY_PROJECT_OTEL_BASE_URL
+            name: GATEWAY_INGEST_BASE_URL
             value: https://logfire-ff-ingest:8443
         documentSelector:
           path: kind


### PR DESCRIPTION
## Summary

- inject the required `GATEWAY_INGEST_BASE_URL` into the Gateway deployment
- use the direct in-cluster `logfire-ff-ingest` service
- select the HTTP or TLS service port from the chart configuration
- cover both HTTP and TLS endpoint rendering in chart unit tests

## Deployment order

Release this chart before deploying the Gateway image from pydantic/platform#33662. The chart supplies the required setting automatically, so self-hosted operators are not prompted for an additional value.

The cloud counterpart is pydantic/platform#33687.

## Validation

- `git diff --check`
- the repository pre-commit checks available without the Helm CLI

The local environment does not have the `helm` or `helm-docs` binaries, so the Helm unit suite could not be run locally. CI will run the chart checks after this push.
