### PR TITLE
Promote chart version to 0.13.40

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40-rc.5
+version: 0.13.40
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40-rc.5](https://img.shields.io/badge/Version-0.13.40--rc.5-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.40](https://img.shields.io/badge/Version-0.13.40-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/tests/cache_routing_test.yaml
+++ b/charts/logfire/tests/cache_routing_test.yaml
@@ -174,6 +174,49 @@ tests:
           path: kind
           value: ClusterRoleBinding
 
+  - it: binds routing RBAC to the service account used by query workloads
+    set:
+      serviceAccount:
+        name: routing-test-sa
+      logfire-ff-query-worker:
+        enabled: true
+      logfire-ff-cache-byte:
+        clientSideRouting:
+          zoneAware: true
+    templates:
+      - templates/logfire-ff-cache-routing-rbac.yaml
+      - templates/logfire-ff-query-api.yaml
+      - templates/logfire-ff-query-worker.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: routing-test-sa
+        template: templates/logfire-ff-query-api.yaml
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: routing-test-sa
+        template: templates/logfire-ff-query-worker.yaml
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: subjects[0].name
+          value: routing-test-sa
+        template: templates/logfire-ff-cache-routing-rbac.yaml
+        documentSelector:
+          path: kind
+          value: RoleBinding
+      - equal:
+          path: subjects[0].name
+          value: routing-test-sa
+        template: templates/logfire-ff-cache-routing-rbac.yaml
+        documentSelector:
+          path: kind
+          value: ClusterRoleBinding
+
   - it: omits routing RBAC when client routing is disabled
     set:
       logfire-ff-cache-byte:


### PR DESCRIPTION
## Summary

Promote the chart to stable `0.13.40`, rolling up the `0.13.40-rc.*` pre-releases since `0.13.39`:

- Update appVersion to `de12a70b` (release `v2026-08-06.01`) (#207)
- Add client-side byte-cache routing, enabled by default in zoneless mode with opt-in zone awareness (#208)
- Configure the remote MCP server's access to the CRUD API for materialized views (#209)
- Set the byte-cache disk capacity from the scratch volume size, fixing startup OOM crash loops on storage classes that report effectively unlimited free space (e.g. EFS) (#210)
- Configure the Gateway ingest endpoint automatically from chart configuration (#211)

Also adds a chart test asserting the client-side routing RBAC binds the service account used by the query workloads.

## Upgrade notes

No action required for standard installs.

- Client-side byte-cache routing creates new namespace-scoped RBAC objects by default: a Role and RoleBinding granting read access to EndpointSlices for direct cache discovery. Cluster-scoped RBAC (read-only node lookup) is only created when opting into `logfire-ff-cache-byte.clientSideRouting.zoneAware`. Setting `logfire-ff-cache-byte.clientSideRouting.enabled: false` renders no routing RBAC and keeps HAProxy routing.
- The byte cache now bounds its disk cache to 80% of its scratch volume size instead of trusting the filesystem's reported free space. To set a different bound, use `logfire-ff-cache-byte.cacheDiskCapacity` (e.g. `"24GB"`).
- Client-side byte-cache routing is enabled by default (zoneless); zone awareness is opt-in via `logfire-ff-cache-byte.clientSideRouting.zoneAware`. HAProxy remains deployed for unmigrated consumers. Zone-aware installations need at least as many cache replicas as query zones.
- `scratchVolume.storage` now accepts fractional Ki/Mi/Gi/Ti quantities (e.g. `1.5Gi`); quantities below 1Mi fail rendering with a clear error. The derived spill quota is now rendered in MiB (`32GB` → `32768MB`) — numerically identical for all presets except `dev`, where it corrects from `1GB` to `512MB`.

### Breaking changes

None.