### PR TITLE
Scope AI gateway routing to the /proxy path segment

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.40
+version: 0.13.41
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.40](https://img.shields.io/badge/Version-0.13.40-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.41](https://img.shields.io/badge/Version-0.13.41-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/logfire-service-config.yaml
+++ b/charts/logfire/templates/logfire-service-config.yaml
@@ -83,7 +83,10 @@ stringData:
       acl path_backend path -i /.well-known/oauth-protected-resource/v1
       acl path_backend path_beg /integrations/
       {{- if (get $aiGatewayValues "enabled") }}
-      acl path_ai_gateway path_beg /proxy /.well-known/oauth-protected-resource/proxy
+      acl path_ai_gateway path /proxy
+      acl path_ai_gateway path_beg /proxy/
+      acl path_ai_gateway path /.well-known/oauth-protected-resource/proxy
+      acl path_ai_gateway path_beg /.well-known/oauth-protected-resource/proxy/
       {{- end }}
       {{- if $remoteMcpEnabled }}
       acl path_remote_mcp path /mcp

--- a/charts/logfire/tests/service_config_test.yaml
+++ b/charts/logfire/tests/service_config_test.yaml
@@ -60,10 +60,21 @@ tests:
     asserts:
       - matchRegex:
           path: stringData["haproxy.cfg"]
-          pattern: "acl path_ai_gateway path_beg /proxy"
+          pattern: "acl path_ai_gateway path /proxy\\n"
+      - matchRegex:
+          path: stringData["haproxy.cfg"]
+          pattern: "acl path_ai_gateway path_beg /proxy/"
       - matchRegex:
           path: stringData["haproxy.cfg"]
           pattern: "use_backend logfire-ai-gateway if path_ai_gateway"
+      # Only the /proxy segment is matched; sibling paths such as hashed
+      # frontend assets (/proxy-<hash>.js) stay on the default backend.
+      - notMatchRegex:
+          path: stringData["haproxy.cfg"]
+          pattern: "path_beg /proxy "
+      - notMatchRegex:
+          path: stringData["haproxy.cfg"]
+          pattern: "path_beg /proxy\\n"
 
   - it: omits the AI gateway routing when its subchart is disabled
     set:


### PR DESCRIPTION
## Summary

- Match `/proxy` and `/proxy/*` as exact path segments in the HAProxy routing, mirroring the remote MCP rules. `path_beg` compares raw string prefixes, so sibling paths that merely start with `/proxy` — e.g. hashed frontend assets like `/proxy-<hash>.js` — were routed to the AI gateway; they now fall through to the frontend backend.
- Apply the same segment scoping to `/.well-known/oauth-protected-resource/proxy`.
- Pin the segment-scoped form in the chart unit tests.
- Promote chart version to 0.13.41.