### PR TITLE
Serve /internal/* from a dedicated backend auth workload

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.42
+version: 0.13.42-rc.1
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.41
+version: 0.13.42
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.42](https://img.shields.io/badge/Version-0.13.42-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.42-rc.1](https://img.shields.io/badge/Version-0.13.42-rc.1-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.41](https://img.shields.io/badge/Version-0.13.41-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.42](https://img.shields.io/badge/Version-0.13.42-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1413,6 +1413,7 @@ Dev Postgres helpers
 {{- $serviceName := .serviceName -}}
 {{- if and $ctx.Values.dev.deployPostgres (has $serviceName (list
   "logfire-backend"
+  "logfire-backend-auth"
   "logfire-worker"
   "logfire-dex"
   "logfire-backend-migrations"

--- a/charts/logfire/templates/logfire-backend-auth.yaml
+++ b/charts/logfire/templates/logfire-backend-auth.yaml
@@ -1,0 +1,181 @@
+{{- /*
+The backend's `auth` deployment profile: the same image as `logfire-backend` on a different
+entrypoint module, serving only the cluster-internal `/internal/*` credential lookups plus the
+health probes.
+
+Not optional, and deliberately has no `enabled` toggle: FusionFire resolves every write and read
+token through `FF_BACKEND_SERVICE_URL`, which points here, and `logfire-backend` serves no
+`/internal/*` route. Without this workload, ingest and query cannot authenticate a token.
+
+No ingress route reaches it either. These endpoints answer "is this token valid, and which
+organization/project is it for" with no authentication of their own, so exposing them on the
+public entry point would turn them into a token-validation oracle. In-cluster callers reach it
+over this ClusterIP Service instead; `logfire-service` (haproxy) has no backend for it.
+*/}}
+{{- $serviceName := "logfire-backend-auth" }}
+{{- $servicePort := 8000 }}
+{{- include "logfire.validate.autoscaling" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- include "logfire.validate.pdb" (dict "Values" .Values "serviceName" $serviceName) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+  annotations:
+    {{- include "logfire.serviceAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 4 }}
+spec:
+  selector:
+    {{- include "logfire.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+  ports:
+  - port: {{ $servicePort }}
+    targetPort: {{ $servicePort }}
+    name: "http"
+  {{- include "logfire.inClusterTls.https.servicePort" (dict "ctx" . "targetPort" "https") | nindent 2 }}
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    {{- include "logfire.labels" . | nindent 4 }}
+    {{- include "logfire.workloadLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+  annotations:
+    {{- include "logfire.workloadAnnotations" (dict "Values" .Values "serviceName" $serviceName "secretSources" (list "postgres" "existing")) | nindent 4 }}
+spec:
+  {{- include "logfire.replicas" (dict "Values" .Values "serviceName" $serviceName) | nindent 2 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "logfire.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ $serviceName }}
+  template:
+    metadata:
+      annotations:
+        {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
+        {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" .) | nindent 8 }}
+        {{- end }}
+        {{- if or (not .Values.existingSecret.enabled) (empty .Values.existingSecret.annotations) }}
+        {{- include "logfire.logfireSecretChecksumAnnotations" (dict "ctx" . "secrets" (list "logfire-jwt-secret")) | nindent 8 }}
+        {{- end }}
+        {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
+      labels:
+        {{- include "logfire.selectorLabels" . | nindent 8 }}
+        {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
+        app.kubernetes.io/component: {{ $serviceName }}
+    spec:
+      {{- include "logfire.standardPodSpecFields" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}
+      containers:
+        - name: {{ $serviceName }}
+          image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $serviceName "Chart" .Chart) }}'
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["python", "-m", "logfire_backend.profiles.auth"]
+          {{- include "logfire.securityContext" .Values.securityContext | nindent 10 }}
+          {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
+          ports:
+            - containerPort: {{ $servicePort }}
+              protocol: TCP
+              name: "http"
+            {{- include "logfire.inClusterTls.https.containerPort" (dict "ctx" .) | nindent 12 }}
+          {{- /*
+          A tighter startup budget than `logfire-backend`: this profile imports a fraction of the
+          route tree, so a boot that takes as long as the catch-all's is a signal, not normal.
+          */}}
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: {{ $servicePort }}
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: {{ $servicePort }}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ $servicePort }}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 2
+          env:
+            - name: APP_PORT
+              value: {{ $servicePort | quote }}
+            - name: LOGFIRE_SERVICE_NAME
+              value: {{ $serviceName }}
+            - name: LOGFIRE_SERVICE_VERSION
+              value: {{ include "logfire.serviceVersion" (dict "root" . "serviceName" $serviceName) | quote }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | quote }}
+            - name: COLLECTOR_OTLP_GRPC_HOST
+              value: http://logfire-otel-collector:4317
+            - name: ON_PREM
+              value: "true"
+            - name: CRUD_PG_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "logfire.postgresSecretName" . }}
+                  key: postgresDsn
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "logfire.secretName" (dict "ctx" . "secretName" "logfire-jwt-secret") }}
+                  key: logfire-jwt-secret
+            {{- /*
+            The token caches this profile writes are the ones FusionFire reads, so the DSN and
+            prefix have to be the same pair `logfire-backend` and the FusionFire workloads use.
+            */}}
+            - name: REDIS_DSN
+              value: {{ .Values.redisDsn }}
+            - name: SHARED_REDIS_DSN
+              value: {{ .Values.redisDsn }}
+            - name: TOKEN_REDIS_DSN
+              value: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "tokenRedis") }}
+            - name: TOKEN_REDIS_PREFIX
+              value: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
+            - name: FRONTEND_HOST
+              value: {{ include "logfire.url" . | quote }}
+            {{- with (include "logfire.intakeOauthResourceUrl" . | trim) }}
+            - name: INTAKE_OAUTH_RESOURCE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if (index .Values "logfire-ai-gateway" "enabled") }}
+            - name: GATEWAY_OAUTH_RESOURCE_URL
+              value: {{ include "logfire.gatewayOauthResourceUrl" . | trim | quote }}
+            {{- end }}
+            {{- include "logfire.rateLimits" . | nindent 12 }}
+            {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
+            - name: LOGFIRE_CA_PATH
+              value: /etc/logfire/incluster-ca/ca.crt
+            - name: HTTPS_PORT
+              value: "{{ .Values.inClusterTls.httpsPort }}"
+            - name: TLS_CERT_PATH
+              value: "/etc/tls/tls.crt"
+            - name: "TLS_KEY_PATH"
+              value: "/etc/tls/tls.key"
+            {{- end }}
+            {{- with (index .Values $serviceName | default dict).env }}
+              {{- . | toYaml | nindent 12 }}
+            {{- end }}
+          {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
+          volumeMounts:
+            {{- include "logfire.inClusterTls.caBundle.volumeMount" (dict "ctx" . "mountPath" "/etc/logfire/incluster-ca") | nindent 12 }}
+            {{- include "logfire.inClusterTls.server.volumeMount" (dict "ctx" . "mountPath" "/etc/tls") | nindent 12 }}
+          {{- end }}
+      {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
+      volumes:
+        {{- include "logfire.inClusterTls.caBundle.volume" (dict "ctx" .) | nindent 8 }}
+        {{- include "logfire.inClusterTls.server.volume" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+{{- template "logfire.autoscaler" (dict "Values" .Values "serviceName" $serviceName) }}
+{{- template "logfire.pdb" (dict "root" $ "serviceName" $serviceName) }}

--- a/charts/logfire/templates/logfire-backend-auth.yaml
+++ b/charts/logfire/templates/logfire-backend-auth.yaml
@@ -1,19 +1,7 @@
-{{- /*
-The backend's `auth` deployment profile: the same image as `logfire-backend` on a different
-entrypoint module, serving only the cluster-internal `/internal/*` credential lookups plus the
-health probes.
-
-Not optional, and deliberately has no `enabled` toggle: FusionFire resolves every write and read
-token through `FF_BACKEND_SERVICE_URL`, which points here, and `logfire-backend` serves no
-`/internal/*` route. Without this workload, ingest and query cannot authenticate a token.
-
-No ingress route reaches it either. These endpoints answer "is this token valid, and which
-organization/project is it for" with no authentication of their own, so exposing them on the
-public entry point would turn them into a token-validation oracle. In-cluster callers reach it
-over this ClusterIP Service instead; `logfire-service` (haproxy) has no backend for it.
-*/}}
 {{- $serviceName := "logfire-backend-auth" }}
 {{- $servicePort := 8000 }}
+{{- $imageTagOwner := "logfire-backend" }}
+{{- if dig "image" "tag" "" (index .Values $serviceName | default dict) }}{{- $imageTagOwner = $serviceName }}{{- end }}
 {{- include "logfire.validate.autoscaling" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- include "logfire.validate.pdb" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: v1
@@ -71,7 +59,7 @@ spec:
       {{- include "logfire.standardPodSpecFields" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}
       containers:
         - name: {{ $serviceName }}
-          image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $serviceName "Chart" .Chart) }}'
+          image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $imageTagOwner "Chart" .Chart) }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           command: ["python", "-m", "logfire_backend.profiles.auth"]
           {{- include "logfire.securityContext" .Values.securityContext | nindent 10 }}
@@ -81,10 +69,6 @@ spec:
               protocol: TCP
               name: "http"
             {{- include "logfire.inClusterTls.https.containerPort" (dict "ctx" .) | nindent 12 }}
-          {{- /*
-          A tighter startup budget than `logfire-backend`: this profile imports a fraction of the
-          route tree, so a boot that takes as long as the catch-all's is a signal, not normal.
-          */}}
           startupProbe:
             httpGet:
               path: /health/live
@@ -113,9 +97,9 @@ spec:
             - name: LOGFIRE_SERVICE_NAME
               value: {{ $serviceName }}
             - name: LOGFIRE_SERVICE_VERSION
-              value: {{ include "logfire.serviceVersion" (dict "root" . "serviceName" $serviceName) | quote }}
+              value: {{ include "logfire.serviceVersion" (dict "root" . "serviceName" $imageTagOwner) | quote }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | quote }}
+              value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $imageTagOwner "codeWorkDir" "/app") | quote }}
             - name: COLLECTOR_OTLP_GRPC_HOST
               value: http://logfire-otel-collector:4317
             - name: ON_PREM
@@ -130,10 +114,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "logfire.secretName" (dict "ctx" . "secretName" "logfire-jwt-secret") }}
                   key: logfire-jwt-secret
-            {{- /*
-            The token caches this profile writes are the ones FusionFire reads, so the DSN and
-            prefix have to be the same pair `logfire-backend` and the FusionFire workloads use.
-            */}}
             - name: REDIS_DSN
               value: {{ .Values.redisDsn }}
             - name: SHARED_REDIS_DSN

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -39,7 +39,8 @@ metadata:
     {{- include "logfire.labels" . | nindent 4 }}
     app.kubernetes.io/component: logfire-ff-config
 data:
-  FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
+  # `/internal/*` is served by the backend's `auth` profile alone, never by `logfire-backend`.
+  FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_DISTRIBUTED_CHANCE: "0"
   FF_RETRY_FAILED_DISTRIBUTED_QUERIES: "false"
   FF_EXTERNAL_TABLES_PG_ENABLED_TABLES: "logfire.annotations,logfire.experiments,logfire.datasets,logfire.dataset_cases,logfire.alerts_ext,logfire.alert_runs_ext,logfire.alert_issues_ext,logfire.filter_alert_issue_hits_ext,logfire.saved_searches_ext"
@@ -86,7 +87,8 @@ metadata:
     {{- include "logfire.labels" . | nindent 4 }}
     app.kubernetes.io/component: logfire-ff-config
 data:
-  FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
+  # `/internal/*` is served by the backend's `auth` profile alone, never by `logfire-backend`.
+  FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
   FF_FAILOVER_OBJECT_STORE_URI: {{ .Values.objectStore.uri }}/_ingest_failover
   FF_INGEST_MAX_TIME_SKEW: "120s"

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -39,7 +39,6 @@ metadata:
     {{- include "logfire.labels" . | nindent 4 }}
     app.kubernetes.io/component: logfire-ff-config
 data:
-  # `/internal/*` is served by the backend's `auth` profile alone, never by `logfire-backend`.
   FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_DISTRIBUTED_CHANCE: "0"
   FF_RETRY_FAILED_DISTRIBUTED_QUERIES: "false"
@@ -87,7 +86,6 @@ metadata:
     {{- include "logfire.labels" . | nindent 4 }}
     app.kubernetes.io/component: logfire-ff-config
 data:
-  # `/internal/*` is served by the backend's `auth` profile alone, never by `logfire-backend`.
   FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
   FF_FAILOVER_OBJECT_STORE_URI: {{ .Values.objectStore.uri }}/_ingest_failover

--- a/charts/logfire/templates/logfire-incluster-tls-certmanager.yaml
+++ b/charts/logfire/templates/logfire-incluster-tls-certmanager.yaml
@@ -9,6 +9,7 @@
 
 {{- $certServices := list
   (dict "serviceName" "logfire-backend")
+  (dict "serviceName" "logfire-backend-auth")
   (dict "serviceName" "logfire-service")
   (dict "serviceName" "logfire-frontend-service")
   (dict "serviceName" "logfire-dex")

--- a/charts/logfire/tests/backend_auth_test.yaml
+++ b/charts/logfire/tests/backend_auth_test.yaml
@@ -119,3 +119,44 @@ tests:
         documentSelector:
           path: metadata.name
           value: logfire-backend-auth-incluster-tls
+
+  - it: follows the backend image tag, so both entrypoints run one image
+    set:
+      logfire-backend:
+        image:
+          tag: pinned-backend
+    templates:
+      - templates/logfire-backend-auth.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":pinned-backend$"
+        documentSelector:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGFIRE_SERVICE_VERSION
+            value: pinned-backend
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: an explicit auth image tag overrides the backend one
+    set:
+      logfire-backend:
+        image:
+          tag: pinned-backend
+      logfire-backend-auth:
+        image:
+          tag: pinned-auth
+    templates:
+      - templates/logfire-backend-auth.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":pinned-auth$"
+        documentSelector:
+          path: kind
+          value: Deployment

--- a/charts/logfire/tests/backend_auth_test.yaml
+++ b/charts/logfire/tests/backend_auth_test.yaml
@@ -1,0 +1,121 @@
+suite: backend auth profile serves the internal endpoints
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+  dev:
+    deployPostgres: true
+tests:
+  - it: renders the auth profile Deployment and Service on the auth entrypoint
+    templates:
+      - templates/logfire-backend-auth.yaml
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: logfire-backend-auth
+          any: true
+      - containsDocument:
+          kind: Service
+          apiVersion: v1
+          name: logfire-backend-auth
+          any: true
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["python", "-m", "logfire_backend.profiles.auth"]
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: FusionFire resolves tokens against the auth profile, not the catch-all backend
+    templates:
+      - templates/logfire-ff-config.yaml
+    asserts:
+      - equal:
+          path: data.FF_BACKEND_SERVICE_URL
+          value: http://logfire-backend-auth:8000
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-ingest-config
+      - equal:
+          path: data.FF_BACKEND_SERVICE_URL
+          value: http://logfire-backend-auth:8000
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-query-config
+
+  - it: FusionFire reaches the auth profile over HTTPS when in-cluster TLS is on
+    set:
+      inClusterTls:
+        enabled: true
+        caBundle:
+          existingConfigMap:
+            name: logfire-incluster-ca
+    templates:
+      - templates/logfire-ff-config.yaml
+    asserts:
+      - equal:
+          path: data.FF_BACKEND_SERVICE_URL
+          value: https://logfire-backend-auth:8443
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-ingest-config
+      - equal:
+          path: data.FF_BACKEND_SERVICE_URL
+          value: https://logfire-backend-auth:8443
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-query-config
+
+  - it: the auth profile shares the token cache and JWT secret with the backend
+    templates:
+      - templates/logfire-backend-auth.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOKEN_REDIS_DSN
+            value: redis://logfire-redis:6379
+        documentSelector:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: logfire-jwt-secret
+                key: logfire-jwt-secret
+        documentSelector:
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ON_PREM
+            value: "true"
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: gets an in-cluster certificate of its own
+    set:
+      inClusterTls:
+        enabled: true
+        certs:
+          mode: certManager
+      dev:
+        deployCertManager: true
+    templates:
+      - templates/logfire-incluster-tls-certmanager.yaml
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: lf-logfire-backend-auth-tls
+        documentSelector:
+          path: metadata.name
+          value: logfire-backend-auth-incluster-tls

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -620,6 +620,45 @@ logfire-ff-maintenance-scheduler:
 #     minAvailable: 1
 
 
+# -- Autoscaling & resources for the `logfire-backend-auth` pod, the backend's `auth`
+# profile. It serves the cluster-internal `/internal/*` credential lookups that FusionFire
+# resolves every write and read token through, and `logfire-backend` serves none of them, so
+# this workload is always deployed and cannot be turned off.
+# logfire-backend-auth:
+#   # -- Workload labels
+#   labels: {}
+#   # -- Workload annotations
+#   annotations: {}
+#   # -- Pod labels
+#   podLabels: {}
+#   # -- Pod annotations
+#   podAnnotations: {}
+#   service:
+#     # -- Service annotations
+#     annotations: {}
+#   # -- Number of replicas
+#   replicas: 2
+#   # -- Resource requests/limits
+#   resources:
+#     cpu: "200m"
+#     memory: "512Mi"
+#   # -- Autoscaler settings
+#   autoscaling:
+#     minReplicas: 2
+#     maxReplicas: 4
+#     hpa:
+#       enabled: true
+#       memAverage: 65
+#       cpuAverage: 60
+#   nodeSelector: {}
+#   affinity: {}
+#   tolerations: []
+#   pdb:
+#     maxUnavailable: 1
+#     minAvailable: 1
+#   # -- Additional environment variables
+#   env: []
+
 # -- Autoscaling & resources for the `logfire-ai-gateway` pod
 # @default -- disabled
 logfire-ai-gateway:
@@ -1814,6 +1853,21 @@ sizingPresets:
           cpuAverage: 45
       pdb:
         maxUnavailable: 1
+    logfire-backend-auth:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "384Mi"
+        limits:
+          memory: "768Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
     logfire-backend:
       resources:
         requests:
@@ -2091,6 +2145,21 @@ sizingPresets:
           labelSelector:
             matchLabels:
               app.kubernetes.io/component: logfire-ff-ingest-processor
+    logfire-backend-auth:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "384Mi"
+        limits:
+          memory: "768Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 4
+        hpa:
+          enabled: true
+          cpuAverage: 50
+      pdb:
+        maxUnavailable: 1
     logfire-backend:
       resources:
         requests:
@@ -2400,6 +2469,34 @@ sizingPresets:
           labelSelector:
             matchLabels:
               app.kubernetes.io/component: logfire-ff-ingest-processor
+    logfire-backend-auth:
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "512Mi"
+        limits:
+          memory: "1Gi"
+      autoscaling:
+        minReplicas: 3
+        maxReplicas: 6
+        hpa:
+          enabled: true
+          cpuAverage: 50
+      pdb:
+        maxUnavailable: 1
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: logfire-backend-auth
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: logfire-backend-auth
     logfire-backend:
       resources:
         requests:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -620,10 +620,7 @@ logfire-ff-maintenance-scheduler:
 #     minAvailable: 1
 
 
-# -- Autoscaling & resources for the `logfire-backend-auth` pod, the backend's `auth`
-# profile. It serves the cluster-internal `/internal/*` credential lookups that FusionFire
-# resolves every write and read token through, and `logfire-backend` serves none of them, so
-# this workload is always deployed and cannot be turned off.
+# -- Autoscaling & resources for the `logfire-backend-auth` pod
 # logfire-backend-auth:
 #   # -- Workload labels
 #   labels: {}

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -21,14 +21,10 @@ async def test_oidc_discovery(client: httpx.AsyncClient) -> None:
 async def test_internal_token_lookups_are_not_exposed(
     client: httpx.AsyncClient, write_token: str, read_token: str, path: str
 ) -> None:
-    """The `/internal/*` credential lookups must not answer from the public entry point.
+    """Driven with real tokens because a reachable endpoint answers `{"state": "active", ...}`.
 
-    They authenticate nobody: hand one a token and it returns that token's organization and
-    project, so a route to them from the edge is a token-validation oracle. Only
-    `logfire-backend-auth` serves them and no haproxy backend points at it, so the request
-    falls through to the frontend. Driven with real tokens because a reachable endpoint
-    answers `{"state": "active", ...}` for these, which is exactly what must not come back;
-    the sibling gateway lookup rides the same router, so it is unreachable by construction.
+    Asserted on the body, not the status: the request falls through to the frontend, which
+    answers 200 with the SPA shell.
     """
     token = write_token if "write" in path else read_token
     response = await client.post(path, json={"token": token})

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -12,3 +12,28 @@ async def test_oidc_discovery(client: httpx.AsyncClient) -> None:
     body = response.json()
     assert body.get("issuer"), body
     assert body.get("token_endpoint"), body
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/internal/write-tokens/get-state", "/internal/read-tokens/get-state"],
+)
+async def test_internal_token_lookups_are_not_exposed(
+    client: httpx.AsyncClient, write_token: str, read_token: str, path: str
+) -> None:
+    """The `/internal/*` credential lookups must not answer from the public entry point.
+
+    They authenticate nobody: hand one a token and it returns that token's organization and
+    project, so a route to them from the edge is a token-validation oracle. Only
+    `logfire-backend-auth` serves them and no haproxy backend points at it, so the request
+    falls through to the frontend. Driven with real tokens because a reachable endpoint
+    answers `{"state": "active", ...}` for these, which is exactly what must not come back;
+    the sibling gateway lookup rides the same router, so it is unreachable by construction.
+    """
+    token = write_token if "write" in path else read_token
+    response = await client.post(path, json={"token": token})
+    try:
+        body = response.json()
+    except ValueError:
+        return
+    assert not isinstance(body, dict) or "state" not in body, body


### PR DESCRIPTION
## Summary

Adds a `logfire-backend-auth` workload that serves the cluster-internal `/internal/*` credential lookups, and points FusionFire's token validation at it instead of `logfire-backend`.

## Upgrade notes

No operator action required. The new workload is deployed automatically and has no `enabled` toggle: FusionFire resolves every write and read token through `FF_BACKEND_SERVICE_URL`, so without it ingest and query cannot authenticate. It is as required as the backend itself.

It adds one small Deployment per install. Under a `sizingPreset` it requests 100m CPU / 384Mi (`tiny`, `small`) or 200m / 512Mi (`standard`, `large`); with no preset it renders no resources, like every other workload. Replica floors match `logfire-backend` for the same preset, so the documented preset trade-offs still hold. Override under a `logfire-backend-auth:` key exactly as for any other workload.

Deployable against the currently pinned `appVersion`, whose image already carries the `auth` profile, so this can merge before the backend change that drops the routes from the catch-all.

### Breaking changes

None.

## Why

`/internal/*` authenticates nobody: hand one of those endpoints a token and it returns that token's organization and project. The network is the only gate. In the platform repo they are being removed from the internet-facing catch-all app for exactly that reason (pydantic/platform#34761), which leaves the `auth` deployment profile as their only home. This chart did not deploy that profile.

## What changed

- **`logfire-backend-auth`**: the same backend image on the `auth` entrypoint (`python -m logfire_backend.profiles.auth`), serving `/internal/*` plus the health probes. ClusterIP only, and no haproxy backend points at it, so nothing routes to it from the edge. The profile imports a fraction of the route tree, so its resources and startup budget are much smaller than the catch-all's.
- **Both FusionFire config maps** (`logfire-ff-ingest-config`, `logfire-ff-query-config`) resolve tokens against it, over HTTPS and the in-cluster port when `inClusterTls` is enabled.
- It joins the in-cluster certificate list and the dev-Postgres wait list, and gets `tiny` / `small` / `standard` sizing-preset entries (`large` inherits `standard`).
- **`ON_PREM`** is set on it: the gateway credential gate narrows the `non_stripe` plan to a single organization unless it is set, which would refuse every self-hosted organization now that the lookup resolves here.

## Tests

- New `charts/logfire/tests/backend_auth_test.yaml`: the workload and Service render on the `auth` entrypoint, both FusionFire config maps point at it in plain and in-cluster-TLS mode, it shares the token-cache Redis and JWT secret with the backend, and it gets a certificate of its own.
- New integration test asserting the token lookups return no token state through the public entry point, driven with real write and read tokens (a reachable endpoint answers `{"state": "active", ...}`, which is exactly what must not come back).
- CI installs with `sizingPreset: tiny`, and the existing ingest tests mint real write tokens, so the new workload is exercised end to end there.

Locally: `helm unittest` 58 passed across 8 suites, `helm lint` clean, and all four presets plus the no-preset path render correctly (`tiny`/`small` HPA 1-4, `standard`/`large` HPA 3-6 with topology spread, no-preset `replicas: 1` and no resources). README regenerated with helm-docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8yUmTYBQDzoJ3CDAwKSLi)_