### PR TITLE
Add Gateway OAuth client bootstrap configuration

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.42-rc.1
+version: 0.13.42-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.42-rc.1](https://img.shields.io/badge/Version-0.13.42-rc.1-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.42-rc.2](https://img.shields.io/badge/Version-0.13.42--rc.2-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/logfire-backend.yaml
+++ b/charts/logfire/templates/logfire-backend.yaml
@@ -1,4 +1,26 @@
 {{- $serviceName := "logfire-backend" }}
+{{- $oauthEnabled := or (include "logfire.effective_tls" . | eq "true") (eq (include "logfire.primary_hostname" .) "localhost") }}
+{{- $oauthClients := list }}
+{{- if $oauthEnabled }}
+  {{- $oauthClients = append $oauthClients (dict
+    "client_id" "logfire-mcp"
+    "client_secret" "$(MCP_OAUTH_CLIENT_SECRET)"
+    "client_name" "Logfire Remote MCP Server"
+    "redirect_uris" (list (printf "%s/mcp/oauth/callback" (include "logfire.url" .)))
+    "allowed_scopes" (list "project:read" "project:write" "project:write_token" "project:read_dashboard" "project:write_dashboard" "project:read_alert" "project:write_alert" "project:read_variables" "project:write_variables" "organization:create_project" "organization:read_channel" "organization:write_channel")
+  ) }}
+  {{- if (index .Values "logfire-ai-gateway" "enabled") }}
+    {{- $oauthClients = append $oauthClients (dict
+      "client_id" (printf "%s/clients/logfire-gateway.json" (include "logfire.url" .))
+      "client_name" "Logfire Gateway CLI"
+      "redirect_uris" (list "http://127.0.0.1/callback" "http://localhost/callback")
+      "allowed_scopes" (list "project:gateway_proxy")
+      "client_type" "public"
+      "grant_types" (list "authorization_code" "refresh_token" "urn:ietf:params:oauth:grant-type:device_code")
+      "require_pkce" true
+    ) }}
+  {{- end }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -250,7 +272,7 @@ spec:
                   name: {{ include "logfire.adminSecretName" (dict "ctx" . "secretName" "logfire-admin-totp-recovery-codes") }}
                   key: logfire-admin-totp-recovery-codes
             {{- /* MCP OAuth2 is not supported without TLS for hostnames different than localhost */ -}}
-            {{- if or (include "logfire.effective_tls" . | eq "true") (eq (include "logfire.primary_hostname" .) "localhost") }}
+            {{- if $oauthEnabled }}
             - name: MCP_OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -262,7 +284,7 @@ spec:
               # This will make it possible to log-in sans-credentials by visiting a URL like:
               # http://localhost:8080/logfire-meta/logfire-meta#token=U8TO1taNdD7YwgBMcfeQVU7RB6Hgtrwd
               # You'll need to get the right host and get the secret from k8s
-              value: '[{"admin_user_email": "{{ .Values.adminEmail }}", "admin_user_password": "$(ADMIN_PASSWORD)", "admin_user_totp_secret": "$(ADMIN_TOTP_SECRET)", "admin_user_totp_recovery_codes": $(ADMIN_TOTP_RECOVERY_CODES), "organization_name": "logfire-meta", "projects": [{"project_name": "logfire-meta", "write_token": "$(META_WRITE_TOKEN)", "permanent_frontend_token": "$(META_FRONTEND_TOKEN)"}]{{- if or (include "logfire.effective_tls" . | eq "true") (eq (include "logfire.primary_hostname" .) "localhost") }}, "oauth_clients": [{"client_id": "logfire-mcp", "client_secret": "$(MCP_OAUTH_CLIENT_SECRET)", "client_name": "Logfire Remote MCP Server", "redirect_uris": ["{{ include "logfire.url" . }}/mcp/oauth/callback"], "allowed_scopes": ["project:read", "project:write", "project:write_token", "project:read_dashboard", "project:write_dashboard", "project:read_alert", "project:write_alert", "project:read_variables", "project:write_variables", "organization:create_project", "organization:read_channel", "organization:write_channel"]}]{{- end }}}]'
+              value: '[{"admin_user_email": "{{ .Values.adminEmail }}", "admin_user_password": "$(ADMIN_PASSWORD)", "admin_user_totp_secret": "$(ADMIN_TOTP_SECRET)", "admin_user_totp_recovery_codes": $(ADMIN_TOTP_RECOVERY_CODES), "organization_name": "logfire-meta", "projects": [{"project_name": "logfire-meta", "write_token": "$(META_WRITE_TOKEN)", "permanent_frontend_token": "$(META_FRONTEND_TOKEN)"}]{{- if $oauthClients }}, "oauth_clients": {{ $oauthClients | toJson }}{{- end }}}]'
             {{- with (index .Values $serviceName | default dict).env }}
               {{- . | toYaml | nindent 12 }}
             {{- end}}

--- a/charts/logfire/tests/gateway_oauth_client_test.yaml
+++ b/charts/logfire/tests/gateway_oauth_client_test.yaml
@@ -1,0 +1,98 @@
+suite: self-hosted gateway OAuth client
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+  dev:
+    deployPostgres: true
+  ingress:
+    enabled: false
+  gateway:
+    tls: true
+    hostnames:
+      - logfire.example.com
+tests:
+  - it: registers the Gateway CLI as a public PKCE client when the AI gateway is enabled
+    set:
+      logfire-ai-gateway:
+        enabled: true
+    templates:
+      - templates/logfire-backend.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"client_id":"https://logfire\.example\.com/clients/logfire-gateway\.json"'
+        documentSelector:
+          path: kind
+          value: Deployment
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"allowed_scopes":\["project:gateway_proxy"\]'
+        documentSelector:
+          path: kind
+          value: Deployment
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"client_type":"public".*"grant_types":\["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:device_code"\].*"require_pkce":true'
+        documentSelector:
+          path: kind
+          value: Deployment
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"redirect_uris":\["http://127\.0\.0\.1/callback","http://localhost/callback"\]'
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: does not register the Gateway CLI when the AI gateway is disabled
+    set:
+      logfire-ai-gateway:
+        enabled: false
+    templates:
+      - templates/logfire-backend.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: 'logfire-gateway\.json'
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: does not enable OAuth clients for a non-local plaintext deployment
+    set:
+      logfire-ai-gateway:
+        enabled: true
+      gateway:
+        tls: false
+        hostnames:
+          - logfire.example.com
+    templates:
+      - templates/logfire-backend.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"oauth_clients"'
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: registers the Gateway CLI for local plaintext development
+    set:
+      logfire-ai-gateway:
+        enabled: true
+      gateway:
+        tls: false
+        hostnames:
+          - localhost
+    templates:
+      - templates/logfire-backend.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
+          pattern: '"client_id":"http://localhost/clients/logfire-gateway\.json"'
+        documentSelector:
+          path: kind
+          value: Deployment


### PR DESCRIPTION
## Summary

Add the Gateway CLI OAuth client to the self-hosted bootstrap configuration.

HTTPS client IDs use CIMD and still require the metadata endpoint added in #217.

Publishes chart prerelease `0.13.42-rc.2`.

## Upgrade notes

No values changes are required.

### Breaking changes

None.
