### PR TITLE
Serve Gateway OAuth client metadata

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.42-rc.2
+version: 0.13.42-rc.3
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.42-rc.2](https://img.shields.io/badge/Version-0.13.42--rc.2-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.42-rc.3](https://img.shields.io/badge/Version-0.13.42--rc.3-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -12,6 +12,10 @@ ingress:
   - logfire.example.com
   maildevHostname: maildev.example.com
 
+# Exercise HTTPS public-URL rendering while the Kind ingress itself remains HTTP.
+gateway:
+  tls: true
+
 objectStore:
   uri: s3://logfire
   env:

--- a/charts/logfire/templates/logfire-backend.yaml
+++ b/charts/logfire/templates/logfire-backend.yaml
@@ -1,5 +1,9 @@
 {{- $serviceName := "logfire-backend" }}
 {{- $oauthEnabled := or (include "logfire.effective_tls" . | eq "true") (eq (include "logfire.primary_hostname" .) "localhost") }}
+{{- $gatewayStaticOauthEnabled := and
+  (not (include "logfire.effective_tls" . | eq "true"))
+  (eq (include "logfire.primary_hostname" .) "localhost")
+-}}
 {{- $oauthClients := list }}
 {{- if $oauthEnabled }}
   {{- $oauthClients = append $oauthClients (dict
@@ -9,7 +13,7 @@
     "redirect_uris" (list (printf "%s/mcp/oauth/callback" (include "logfire.url" .)))
     "allowed_scopes" (list "project:read" "project:write" "project:write_token" "project:read_dashboard" "project:write_dashboard" "project:read_alert" "project:write_alert" "project:read_variables" "project:write_variables" "organization:create_project" "organization:read_channel" "organization:write_channel")
   ) }}
-  {{- if (index .Values "logfire-ai-gateway" "enabled") }}
+  {{- if and $gatewayStaticOauthEnabled (index .Values "logfire-ai-gateway" "enabled") }}
     {{- $oauthClients = append $oauthClients (dict
       "client_id" (printf "%s/clients/logfire-gateway.json" (include "logfire.url" .))
       "client_name" "Logfire Gateway CLI"

--- a/charts/logfire/templates/logfire-frontend-service-config.yaml
+++ b/charts/logfire/templates/logfire-frontend-service-config.yaml
@@ -11,6 +11,8 @@
   "response_types" (list "code")
   "token_endpoint_auth_method" "none"
   "scope" "project:gateway_proxy"
+  "client_uri" "https://pydantic.dev/docs/ai/overview/gateway/"
+  "logo_uri" "https://logfire.pydantic.dev/clients/logfire-gateway.svg"
 -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/logfire/templates/logfire-frontend-service-config.yaml
+++ b/charts/logfire/templates/logfire-frontend-service-config.yaml
@@ -1,6 +1,17 @@
 {{- $tls := include "logfire.effective_tls" . | eq "true" -}}
 {{- $hostnames := include "logfire.all_hostnames_string" . | splitList " " -}}
 {{- $wsProtocol := $tls | default false | ternary "wss" "ws" -}}
+{{- $gatewayCimdEnabled := and $tls (index .Values "logfire-ai-gateway" "enabled") -}}
+{{- $gatewayClientId := printf "%s/clients/logfire-gateway.json" (include "logfire.url" .) -}}
+{{- $gatewayClientMetadata := dict
+  "client_id" $gatewayClientId
+  "client_name" "Logfire Gateway CLI"
+  "redirect_uris" (list "http://127.0.0.1/callback" "http://localhost/callback")
+  "grant_types" (list "authorization_code" "refresh_token" "urn:ietf:params:oauth:grant-type:device_code")
+  "response_types" (list "code")
+  "token_endpoint_auth_method" "none"
+  "scope" "project:gateway_proxy"
+-}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -98,6 +109,16 @@ data:
                 add_header Content-Type text/plain;
                 return 200 "ok\n";
             }
+
+            {{- if $gatewayCimdEnabled }}
+            # OAuth Client ID Metadata Document used by the Gateway CLI.
+            location = /clients/logfire-gateway.json {
+                default_type application/json;
+                add_header Cache-Control "public, max-age=300";
+                add_header X-Content-Type-Options "nosniff" always;
+                return 200 '{{ $gatewayClientMetadata | toJson }}';
+            }
+            {{- end }}
 
             # Enhanced JSON view render worker. This worker executes saved/transpiled
             # view code, so it gets a tighter policy than the main app chunks.
@@ -261,6 +282,16 @@ data:
                 add_header Content-Type text/plain;
                 return 200 "ok\n";
             }
+
+            {{- if $gatewayCimdEnabled }}
+            # OAuth Client ID Metadata Document used by the Gateway CLI.
+            location = /clients/logfire-gateway.json {
+                default_type application/json;
+                add_header Cache-Control "public, max-age=300";
+                add_header X-Content-Type-Options "nosniff" always;
+                return 200 '{{ $gatewayClientMetadata | toJson }}';
+            }
+            {{- end }}
 
             # Enhanced JSON view render worker. This worker executes saved/transpiled
             # view code, so it gets a tighter policy than the main app chunks.

--- a/charts/logfire/tests/gateway_oauth_client_test.yaml
+++ b/charts/logfire/tests/gateway_oauth_client_test.yaml
@@ -15,34 +15,16 @@ set:
     hostnames:
       - logfire.example.com
 tests:
-  - it: registers the Gateway CLI as a public PKCE client when the AI gateway is enabled
+  - it: does not statically register the Gateway CLI for a TLS CIMD deployment
     set:
       logfire-ai-gateway:
         enabled: true
     templates:
       - templates/logfire-backend.yaml
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
-          pattern: '"client_id":"https://logfire\.example\.com/clients/logfire-gateway\.json"'
-        documentSelector:
-          path: kind
-          value: Deployment
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
-          pattern: '"allowed_scopes":\["project:gateway_proxy"\]'
-        documentSelector:
-          path: kind
-          value: Deployment
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
-          pattern: '"client_type":"public".*"grant_types":\["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:device_code"\].*"require_pkce":true'
-        documentSelector:
-          path: kind
-          value: Deployment
-      - matchRegex:
-          path: spec.template.spec.containers[0].env[?(@.name == "BOOTSTRAPPED_ORGANIZATIONS")].value
-          pattern: '"redirect_uris":\["http://127\.0\.0\.1/callback","http://localhost/callback"\]'
+          pattern: 'logfire-gateway\.json'
         documentSelector:
           path: kind
           value: Deployment
@@ -75,6 +57,18 @@ tests:
       - matchRegex:
           path: data["nginx.conf"]
           pattern: '"token_endpoint_auth_method":"none"'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"client_uri":"https://pydantic\.dev/docs/ai/overview/gateway/"'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"logo_uri":"https://logfire\.pydantic\.dev/clients/logfire-gateway\.svg"'
         documentSelector:
           path: metadata.name
           value: logfire-frontend-nginx-config

--- a/charts/logfire/tests/gateway_oauth_client_test.yaml
+++ b/charts/logfire/tests/gateway_oauth_client_test.yaml
@@ -47,6 +47,38 @@ tests:
           path: kind
           value: Deployment
 
+  - it: serves the Gateway CLI client metadata document when TLS and the AI gateway are enabled
+    set:
+      logfire-ai-gateway:
+        enabled: true
+    templates:
+      - templates/logfire-frontend-service-config.yaml
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location = /clients/logfire-gateway\.json'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"client_id":"https://logfire\.example\.com/clients/logfire-gateway\.json"'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"grant_types":\["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:device_code"\]'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"token_endpoint_auth_method":"none"'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
+
   - it: does not register the Gateway CLI when the AI gateway is disabled
     set:
       logfire-ai-gateway:
@@ -60,6 +92,20 @@ tests:
         documentSelector:
           path: kind
           value: Deployment
+
+  - it: does not serve client metadata when the AI gateway is disabled
+    set:
+      logfire-ai-gateway:
+        enabled: false
+    templates:
+      - templates/logfire-frontend-service-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'logfire-gateway\.json'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
 
   - it: does not enable OAuth clients for a non-local plaintext deployment
     set:
@@ -78,6 +124,24 @@ tests:
         documentSelector:
           path: kind
           value: Deployment
+
+  - it: does not serve CIMD over plaintext
+    set:
+      logfire-ai-gateway:
+        enabled: true
+      gateway:
+        tls: false
+        hostnames:
+          - logfire.example.com
+    templates:
+      - templates/logfire-frontend-service-config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'logfire-gateway\.json'
+        documentSelector:
+          path: metadata.name
+          value: logfire-frontend-nginx-config
 
   - it: registers the Gateway CLI for local plaintext development
     set:

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -23,6 +23,7 @@ async def test_gateway_client_metadata_document(client: httpx.AsyncClient) -> No
     assert body == {
         "client_id": "https://logfire.example.com/clients/logfire-gateway.json",
         "client_name": "Logfire Gateway CLI",
+        "client_uri": "https://pydantic.dev/docs/ai/overview/gateway/",
         "grant_types": [
             "authorization_code",
             "refresh_token",
@@ -30,6 +31,7 @@ async def test_gateway_client_metadata_document(client: httpx.AsyncClient) -> No
         ],
         "redirect_uris": ["http://127.0.0.1/callback", "http://localhost/callback"],
         "response_types": ["code"],
+        "logo_uri": "https://logfire.pydantic.dev/clients/logfire-gateway.svg",
         "scope": "project:gateway_proxy",
         "token_endpoint_auth_method": "none",
     }

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -14,6 +14,27 @@ async def test_oidc_discovery(client: httpx.AsyncClient) -> None:
     assert body.get("token_endpoint"), body
 
 
+async def test_gateway_client_metadata_document(client: httpx.AsyncClient) -> None:
+    response = await client.get("/clients/logfire-gateway.json")
+    assert response.is_success, response.text
+    assert response.headers["content-type"].startswith("application/json")
+
+    body = response.json()
+    assert body == {
+        "client_id": "https://logfire.example.com/clients/logfire-gateway.json",
+        "client_name": "Logfire Gateway CLI",
+        "grant_types": [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ],
+        "redirect_uris": ["http://127.0.0.1/callback", "http://localhost/callback"],
+        "response_types": ["code"],
+        "scope": "project:gateway_proxy",
+        "token_endpoint_auth_method": "none",
+    }
+
+
 @pytest.mark.parametrize(
     "path",
     ["/internal/write-tokens/get-state", "/internal/read-tokens/get-state"],


### PR DESCRIPTION
## Summary

Serve the Gateway CLI OAuth client metadata document for HTTPS self-hosted installations. Without it, the CLI's URL-shaped client ID resolves to the frontend instead of valid OAuth metadata, so OAuth client validation fails.

Publishes chart prerelease `0.13.42-rc.3`.

## Upgrade notes

No values changes are required.

### Breaking changes

None.
