### PR TITLE
Promote chart version to 0.13.42

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.42-rc.3
+version: 0.13.42
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.42-rc.3](https://img.shields.io/badge/Version-0.13.42--rc.3-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.42](https://img.shields.io/badge/Version-0.13.42-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 


### PR DESCRIPTION
## Summary

Promote chart `0.13.42` to stable.

This release adds dedicated backend authentication routing for internal endpoints and enables Gateway CLI OAuth on self-hosted HTTPS installations by serving its client metadata document.

## Upgrade notes

No chart values changes are required.

### Breaking changes

None.