### PR TITLE
Avoid rollouts for chart-version-only changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Chart linting
         run: ct lint --config ci/ct.yaml --target-branch "$CT_TARGET_BRANCH"
 
+      - name: Check version-stable configuration checksums
+        run: ci/check-version-stable-checksums.sh
+
       - name: Set up GCP auth
         id: auth
         uses: google-github-actions/auth@v2

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.42
+version: 0.13.43-rc.1
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.42](https://img.shields.io/badge/Version-0.13.42-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.43-rc.1](https://img.shields.io/badge/Version-0.13.43--rc.1-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -414,6 +414,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Hash rendered configuration without the chart-version label. The label is
+resource metadata and must not restart workloads during a version-only chart
+promotion.
+*/}}
+{{- define "logfire.configChecksum" -}}
+{{- regexReplaceAll `(?m)^[ \t]*helm[.]sh/chart:[^\n]*\n?` . "" | sha256sum -}}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "logfire.selectorLabels" -}}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -419,7 +419,7 @@ resource metadata and must not restart workloads during a version-only chart
 promotion.
 */}}
 {{- define "logfire.configChecksum" -}}
-{{- regexReplaceAll `(?m)^[ \t]*helm[.]sh/chart:[^\n]*\n?` . "" | sha256sum -}}
+{{- regexReplaceAll `(?m)(^metadata:\n(?:^[ \t]+[^\n]*\n)*?^[ \t]+labels:\n)[ \t]+helm[.]sh/chart:[^\n]*\n` . `${1}` | sha256sum -}}
 {{- end }}
 
 {{/*

--- a/charts/logfire/templates/dex/deployment.yaml
+++ b/charts/logfire/templates/dex/deployment.yaml
@@ -48,7 +48,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/dex/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/dex/secret.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
       labels:

--- a/charts/logfire/templates/logfire-ff-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-cache-byte.yaml
@@ -55,7 +55,7 @@ spec:
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
     spec:
       {{- if .Values.priorityClassName }}

--- a/charts/logfire/templates/logfire-ff-compaction-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-compaction-worker.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-ff-crud-api.yaml
+++ b/charts/logfire/templates/logfire-ff-crud-api.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
       labels:
         {{- include "logfire.selectorLabels" . | nindent 8 }}
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}

--- a/charts/logfire/templates/logfire-ff-ingest-processor.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest-processor.yaml
@@ -47,7 +47,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}

--- a/charts/logfire/templates/logfire-ff-ingest.yaml
+++ b/charts/logfire/templates/logfire-ff-ingest.yaml
@@ -53,7 +53,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}

--- a/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-scheduler.yaml
@@ -26,7 +26,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-maintenance-worker.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-ff-proxy-cache-byte.yaml
+++ b/charts/logfire/templates/logfire-ff-proxy-cache-byte.yaml
@@ -51,7 +51,7 @@ spec:
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
         {{- include "logfire.secretChecksumAnnotation" (dict "ctx" . "annotationKey" "checksum/logfire-cache-byte-haproxy-config" "name" "logfire-cache-byte-haproxy-config" "key" "haproxy.cfg") | nindent 8 }}
-        checksum/service-config: {{ include (print $.Template.BasePath "/logfire-service-config.yaml") . | sha256sum }}
+        checksum/service-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-service-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $proxyServiceName) | nindent 8 }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
     spec:

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -48,7 +48,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/ff-config: {{ include (print $.Template.BasePath "/logfire-ff-config.yaml") . | sha256sum }}
+        checksum/ff-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-ff-config.yaml") .) }}
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" . "key" "postgresFFDsn") | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-frontend-service.yaml
+++ b/charts/logfire/templates/logfire-frontend-service.yaml
@@ -45,7 +45,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/service-config: {{ include (print $.Template.BasePath "/logfire-frontend-service-config.yaml") . | sha256sum }}
+        checksum/service-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-frontend-service-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
     spec:

--- a/charts/logfire/templates/logfire-otel-collector.yaml
+++ b/charts/logfire/templates/logfire-otel-collector.yaml
@@ -103,7 +103,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/logfire-otel-collector-cfg.yaml") . | sha256sum }}
+        checksum/config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-otel-collector-cfg.yaml") .) }}
         {{- if or (not .Values.existingSecret.enabled) (empty .Values.existingSecret.annotations) }}
         {{- include "logfire.logfireSecretChecksumAnnotations" (dict "ctx" . "secrets" (list "logfire-meta-write-token")) | nindent 8 }}
         {{- end }}

--- a/charts/logfire/templates/logfire-service.yaml
+++ b/charts/logfire/templates/logfire-service.yaml
@@ -42,7 +42,7 @@ spec:
         {{- include "logfire.podLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceName }}
       annotations:
-        checksum/service-config: {{ include (print $.Template.BasePath "/logfire-service-config.yaml") . | sha256sum }}
+        checksum/service-config: {{ include "logfire.configChecksum" (include (print $.Template.BasePath "/logfire-service-config.yaml") .) }}
         {{- include "logfire.inClusterTls.server.checksumAnnotation" (dict "ctx" . "serviceName" $serviceName) | nindent 8 }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
     spec:

--- a/ci/check-version-stable-checksums.sh
+++ b/ci/check-version-stable-checksums.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cp -R "$repo_root/charts/logfire" "$tmp_dir/base"
+cp -R "$tmp_dir/base" "$tmp_dir/version-change"
+
+sed -i.bak 's/^version:.*/version: 999.999.999/' "$tmp_dir/version-change/Chart.yaml"
+rm "$tmp_dir/version-change/Chart.yaml.bak"
+
+render() {
+  local chart=$1
+  shift
+  helm template checksum-test "$chart" \
+    --set-string adminEmail=test@example.com \
+    --set-string objectStore.uri=s3://test-bucket \
+    --set existingSecret.enabled=true \
+    --set-string existingSecret.name=logfire-secrets \
+    --set postgresSecret.enabled=true \
+    --set-string postgresSecret.name=postgres-secrets \
+    "$@"
+}
+
+checksums() {
+  awk '/checksum\/(config|ff-config|service-config):/ { print }' | sort
+}
+
+render "$tmp_dir/base" | checksums >"$tmp_dir/base-checksums"
+render "$tmp_dir/version-change" | checksums >"$tmp_dir/version-checksums"
+
+if [[ ! -s "$tmp_dir/base-checksums" ]]; then
+  echo "No configuration checksum annotations were rendered" >&2
+  exit 1
+fi
+
+if ! diff -u "$tmp_dir/base-checksums" "$tmp_dir/version-checksums"; then
+  echo "A chart-version-only change altered workload configuration checksums" >&2
+  exit 1
+fi
+
+render "$tmp_dir/base" --set-string redisDsn=redis://changed:6379 | checksums >"$tmp_dir/config-change-checksums"
+
+if cmp -s "$tmp_dir/base-checksums" "$tmp_dir/config-change-checksums"; then
+  echo "A configuration change did not alter workload configuration checksums" >&2
+  exit 1
+fi

--- a/ci/check-version-stable-checksums.sh
+++ b/ci/check-version-stable-checksums.sh
@@ -47,3 +47,11 @@ if cmp -s "$tmp_dir/base-checksums" "$tmp_dir/config-change-checksums"; then
   echo "A configuration change did not alter workload configuration checksums" >&2
   exit 1
 fi
+
+render "$tmp_dir/base" --set-string 'otel_collector.exporter.headers.helm\.sh/chart=before' | checksums >"$tmp_dir/header-before-checksums"
+render "$tmp_dir/base" --set-string 'otel_collector.exporter.headers.helm\.sh/chart=after' | checksums >"$tmp_dir/header-after-checksums"
+
+if cmp -s "$tmp_dir/header-before-checksums" "$tmp_dir/header-after-checksums"; then
+  echo "A user configuration key named helm.sh/chart was excluded from workload configuration checksums" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Prevents chart-version metadata from changing workload configuration checksums, avoiding unnecessary pod rollouts during version-only chart promotions. Adds a regression check that preserves rollouts for real configuration changes.

## Upgrade notes

None.

### Breaking changes

None.