### PR TITLE
Build chart dependencies before checksum CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,11 @@ jobs:
         run: ct lint --config ci/ct.yaml --target-branch "$CT_TARGET_BRANCH"
 
       - name: Check version-stable configuration checksums
-        run: ci/check-version-stable-checksums.sh
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add jetstack https://charts.jetstack.io
+          helm dependency build charts/logfire
+          ci/check-version-stable-checksums.sh
 
       - name: Set up GCP auth
         id: auth


### PR DESCRIPTION
## Summary

Ensures the checksum regression can run on main-branch pushes by building chart dependencies explicitly.

## Upgrade notes

None.

### Breaking changes

None.