### PR TITLE
Deepen FusionFire query execution module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,8 @@
+# Domain context
+
+## FusionFire query execution settings
+
+The resolved runtime settings that control how a FusionFire query process uses
+CPU, memory, DataFusion threads, I/O parallelism, and per-worker query capacity.
+They do not decide whether queries execute in the query intake workload or in a
+remote query worker; workload topology owns that choice.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,0 @@
-# Domain context
-
-## FusionFire query execution settings
-
-The resolved runtime settings that control how a FusionFire query process uses
-CPU, memory, DataFusion threads, I/O parallelism, and per-worker query capacity.
-They do not decide whether queries execute in the query intake workload or in a
-remote query worker; workload topology owns that choice.

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -195,16 +195,16 @@ request when no limit is configured), rounded up to whole cores.
 {{/*
 Render the complete FusionFire query execution environment shared by the query
 intake and remote query worker adapters. The caller owns workload topology and
-states whether this process executes DataFusion queries; this module owns the
-resulting settings and preserves each adapter's established environment order.
+passes its resulting role; this module owns the settings for that role and
+preserves the established environment order.
 */}}
 {{- define "logfire.ffQueryExecutionEnv" -}}
 {{- $serviceName := required "logfire.ffQueryExecutionEnv: need .serviceName" .serviceName -}}
-{{- $adapter := required "logfire.ffQueryExecutionEnv: need .adapter" .adapter -}}
-{{- if not (has $adapter (list "query-intake" "query-worker")) -}}
-  {{- fail (printf "logfire.ffQueryExecutionEnv: unknown adapter %q" $adapter) -}}
+{{- $role := required "logfire.ffQueryExecutionEnv: need .role" .role -}}
+{{- if not (has $role (list "combined" "intake" "worker")) -}}
+  {{- fail (printf "logfire.ffQueryExecutionEnv: unknown role %q" $role) -}}
 {{- end -}}
-{{- $executesQueries := .executesQueries | default false -}}
+{{- $executesQueries := ne $role "intake" -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
 {{- $queryParallelism := include "logfire.ffQueryParallelism" . -}}
 {{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
@@ -217,7 +217,7 @@ resulting settings and preserves each adapter's established environment order.
 - name: FF_MAX_COST_PER_WORKER
   value: {{ $maxCostPerWorker | quote }}
 {{ include "logfire.ffResourceEnv" . }}
-{{- if eq $adapter "query-worker" }}
+{{- if eq $role "worker" }}
 - name: FF_PG_POOL_MAX_CONNECTIONS
   value: "4"
 {{- end }}
@@ -228,22 +228,22 @@ resulting settings and preserves each adapter's established environment order.
   value: {{ include "logfire.ffDatafusionThreads" . | quote }}
 - name: FF_DATAFUSION_MEMORY_LIMIT
   value: {{ get $effectiveServiceValues "datafusionMemory" | default "auto" | quote }}
-{{- if and (eq $adapter "query-intake") (hasKey $effectiveServiceValues "datafusionTargetPartitions") }}
+{{- if and (eq $role "combined") (hasKey $effectiveServiceValues "datafusionTargetPartitions") }}
 - name: FF_DATAFUSION_TARGET_PARTITIONS
   value: {{ get $effectiveServiceValues "datafusionTargetPartitions" | quote }}
 {{- end }}
-{{- if and (eq $adapter "query-intake") (hasKey $effectiveServiceValues "datafusionBatchSize") }}
+{{- if and (eq $role "combined") (hasKey $effectiveServiceValues "datafusionBatchSize") }}
 - name: FF_DATAFUSION_BATCH_SIZE
   value: {{ get $effectiveServiceValues "datafusionBatchSize" | quote }}
 {{- end }}
-{{- if eq $adapter "query-worker" }}
+{{- if eq $role "worker" }}
 - name: FF_DATAFUSION_THREAD_STACK_SIZE
   value: "8MB"
 {{- end }}
 - name: FF_IO_THREAD_STACK_SIZE
   value: "8MB"
 {{- end }}
-{{- if eq $adapter "query-intake" }}
+{{- if ne $role "worker" }}
 - name: FF_DATAFUSION_THREAD_STACK_SIZE
   value: "8MB"
 {{- end }}

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -162,14 +162,6 @@ without rendering Kubernetes resources.
 {{- end -}}
 
 {{/*
-Resolve per-query DataFusion I/O parallelism independently for each service.
-*/}}
-{{- define "logfire.ffQueryParallelism" -}}
-{{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
-{{- get $effectiveServiceValues "queryParallelism" | default "auto" -}}
-{{- end -}}
-
-{{/*
 Resolve worker query capacity consistently for the combined query-api deployment
 and optional remote query workers. An explicit query-api override wins.
 Otherwise, derive capacity from the execution worker's effective CPU limit (or
@@ -206,7 +198,7 @@ preserves the established environment order.
 {{- end -}}
 {{- $executesQueries := ne $role "intake" -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
-{{- $queryParallelism := include "logfire.ffQueryParallelism" . -}}
+{{- $queryParallelism := get $effectiveServiceValues "queryParallelism" | default "auto" -}}
 {{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
 - name: FF_ENABLE_SPILL_TO_DISK
   value: "true"

--- a/charts/logfire/templates/_helpers-fusionfire.tpl
+++ b/charts/logfire/templates/_helpers-fusionfire.tpl
@@ -193,18 +193,59 @@ request when no limit is configured), rounded up to whole cores.
 {{- end -}}
 
 {{/*
-Optional DataFusion query execution overrides. When omitted, FusionFire keeps
-its own defaults and auto-config behavior.
+Render the complete FusionFire query execution environment shared by the query
+intake and remote query worker adapters. The caller owns workload topology and
+states whether this process executes DataFusion queries; this module owns the
+resulting settings and preserves each adapter's established environment order.
 */}}
 {{- define "logfire.ffQueryExecutionEnv" -}}
+{{- $serviceName := required "logfire.ffQueryExecutionEnv: need .serviceName" .serviceName -}}
+{{- $adapter := required "logfire.ffQueryExecutionEnv: need .adapter" .adapter -}}
+{{- if not (has $adapter (list "query-intake" "query-worker")) -}}
+  {{- fail (printf "logfire.ffQueryExecutionEnv: unknown adapter %q" $adapter) -}}
+{{- end -}}
+{{- $executesQueries := .executesQueries | default false -}}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" . | fromJson -}}
-{{- if hasKey $effectiveServiceValues "datafusionTargetPartitions" }}
+{{- $queryParallelism := include "logfire.ffQueryParallelism" . -}}
+{{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
+- name: FF_ENABLE_SPILL_TO_DISK
+  value: "true"
+- name: FF_TEMP_DIR
+  value: /scratch/fusionfire
+- name: FF_QUERY_PARALLELISM
+  value: {{ $queryParallelism | quote }}
+- name: FF_MAX_COST_PER_WORKER
+  value: {{ $maxCostPerWorker | quote }}
+{{ include "logfire.ffResourceEnv" . }}
+{{- if eq $adapter "query-worker" }}
+- name: FF_PG_POOL_MAX_CONNECTIONS
+  value: "4"
+{{- end }}
+{{- if $executesQueries }}
+- name: FF_IO_THREADS
+  value: {{ include "logfire.ffIoThreads" . | quote }}
+- name: FF_DATAFUSION_THREADS
+  value: {{ include "logfire.ffDatafusionThreads" . | quote }}
+- name: FF_DATAFUSION_MEMORY_LIMIT
+  value: {{ get $effectiveServiceValues "datafusionMemory" | default "auto" | quote }}
+{{- if and (eq $adapter "query-intake") (hasKey $effectiveServiceValues "datafusionTargetPartitions") }}
 - name: FF_DATAFUSION_TARGET_PARTITIONS
   value: {{ get $effectiveServiceValues "datafusionTargetPartitions" | quote }}
 {{- end }}
-{{- if hasKey $effectiveServiceValues "datafusionBatchSize" }}
+{{- if and (eq $adapter "query-intake") (hasKey $effectiveServiceValues "datafusionBatchSize") }}
 - name: FF_DATAFUSION_BATCH_SIZE
   value: {{ get $effectiveServiceValues "datafusionBatchSize" | quote }}
+{{- end }}
+{{- if eq $adapter "query-worker" }}
+- name: FF_DATAFUSION_THREAD_STACK_SIZE
+  value: "8MB"
+{{- end }}
+- name: FF_IO_THREAD_STACK_SIZE
+  value: "8MB"
+{{- end }}
+{{- if eq $adapter "query-intake" }}
+- name: FF_DATAFUSION_THREAD_STACK_SIZE
+  value: "8MB"
 {{- end }}
 {{- end -}}
 

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -1,9 +1,6 @@
 {{- $serviceName := "logfire-ff-query-api" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
-{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- $remoteQueryWorkerEnabled := get (get .Values "logfire-ff-query-worker" | default dict) "enabled" | default false -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -65,7 +62,7 @@ spec:
           command:
             {{- include "logfire.ffCommandWithTempDirCleanup" . | nindent 12 }}
           args:
-            {{- if (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
+            {{- if $remoteQueryWorkerEnabled }}
             - query
             {{- else }}
             - query-worker
@@ -83,29 +80,8 @@ spec:
                 name: logfire-ff-query-config
           env:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
-            - name: FF_ENABLE_SPILL_TO_DISK
-              value: "true"
-            - name: FF_TEMP_DIR
-              value: /scratch/fusionfire
-            - name: FF_QUERY_PARALLELISM
-              value: {{ $queryParallelism | quote }}
-            - name: FF_MAX_COST_PER_WORKER
-              value: {{ $maxCostPerWorker | quote }}
-            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
-            {{- if not (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
-            - name: FF_IO_THREADS
-              value: {{ $ioThreads | quote }}
-            - name: FF_DATAFUSION_THREADS
-              value: {{ $datafusionThreads | quote }}
-            - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
-            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
-            - name: FF_IO_THREAD_STACK_SIZE
-              value: "8MB"
-            {{- end }}
-            - name: FF_DATAFUSION_THREAD_STACK_SIZE
-              value: "8MB"
-            {{- if (get (get .Values "logfire-ff-query-worker" | default  dict) "enabled") }}
+            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "adapter" "query-intake" "executesQueries" (not $remoteQueryWorkerEnabled)) | nindent 12 }}
+            {{- if $remoteQueryWorkerEnabled }}
             - name: FF_TLS_CLIENT_SNI_HOSTNAME
               value: "logfire-ff-query-worker"
             {{- end }}

--- a/charts/logfire/templates/logfire-ff-query-api.yaml
+++ b/charts/logfire/templates/logfire-ff-query-api.yaml
@@ -1,6 +1,7 @@
 {{- $serviceName := "logfire-ff-query-api" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
 {{- $remoteQueryWorkerEnabled := get (get .Values "logfire-ff-query-worker" | default dict) "enabled" | default false -}}
+{{- $queryExecutionRole := ternary "intake" "combined" $remoteQueryWorkerEnabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -80,7 +81,7 @@ spec:
                 name: logfire-ff-query-config
           env:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
-            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "adapter" "query-intake" "executesQueries" (not $remoteQueryWorkerEnabled)) | nindent 12 }}
+            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "role" $queryExecutionRole) | nindent 12 }}
             {{- if $remoteQueryWorkerEnabled }}
             - name: FF_TLS_CLIENT_SNI_HOSTNAME
               value: "logfire-ff-query-worker"

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -1,9 +1,5 @@
 {{- $serviceName := "logfire-ff-query-worker" }}
 {{- $effectiveServiceValues := include "logfire.effectiveServiceValues" (dict "Values" .Values "serviceName" $serviceName) | fromJson -}}
-{{- $queryParallelism := include "logfire.ffQueryParallelism" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $maxCostPerWorker := include "logfire.ffMaxCostPerWorker" (dict "Values" .Values) -}}
-{{- $ioThreads := include "logfire.ffIoThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- $datafusionThreads := include "logfire.ffDatafusionThreads" (dict "Values" .Values "serviceName" $serviceName) -}}
 {{- if (index .Values $serviceName | default dict).enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -60,27 +56,7 @@ spec:
                 name: logfire-ff-query-config
           env:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
-            - name: FF_ENABLE_SPILL_TO_DISK
-              value: "true"
-            - name: FF_TEMP_DIR
-              value: /scratch/fusionfire
-            - name: FF_QUERY_PARALLELISM
-              value: {{ $queryParallelism | quote }}
-            - name: FF_MAX_COST_PER_WORKER
-              value: {{ $maxCostPerWorker | quote }}
-            {{- include "logfire.ffResourceEnv" (dict "Values" .Values "serviceName" $serviceName) | nindent 12 }}
-            - name: FF_PG_POOL_MAX_CONNECTIONS
-              value: "4"
-            - name: FF_IO_THREADS
-              value: {{ $ioThreads | quote }}
-            - name: FF_DATAFUSION_THREADS
-              value: {{ $datafusionThreads | quote }}
-            - name: FF_DATAFUSION_MEMORY_LIMIT
-              value: {{ (get $effectiveServiceValues "datafusionMemory" | default "auto" | quote) }}
-            - name: FF_DATAFUSION_THREAD_STACK_SIZE
-              value: "8MB"
-            - name: FF_IO_THREAD_STACK_SIZE
-              value: "8MB"
+            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "adapter" "query-worker" "executesQueries" true) | nindent 12 }}
             - name: FF_TLS_CLIENT_SNI_HOSTNAME
               value: "logfire-ff-query-worker"
             - name: FF_REDIS_TAIL_DSN

--- a/charts/logfire/templates/logfire-ff-query-worker.yaml
+++ b/charts/logfire/templates/logfire-ff-query-worker.yaml
@@ -56,7 +56,7 @@ spec:
                 name: logfire-ff-query-config
           env:
             {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
-            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "adapter" "query-worker" "executesQueries" true) | nindent 12 }}
+            {{- include "logfire.ffQueryExecutionEnv" (dict "Values" .Values "serviceName" $serviceName "role" "worker") | nindent 12 }}
             - name: FF_TLS_CLIENT_SNI_HOSTNAME
               value: "logfire-ff-query-worker"
             - name: FF_REDIS_TAIL_DSN

--- a/charts/logfire/tests/query_execution_test.yaml
+++ b/charts/logfire/tests/query_execution_test.yaml
@@ -13,11 +13,7 @@ tests:
     set:
       logfire-ff-query-api:
         queryParallelism: "7"
-        maxQueryCostPerPod: 9
         ioThreads: "5"
-        datafusionThreads: "6"
-        datafusionMemory: 3Gi
-        datafusionTargetPartitions: 4
         datafusionBatchSize: 2048
     templates:
       - templates/logfire-ff-query-api.yaml
@@ -30,23 +26,7 @@ tests:
           value: Deployment
       - contains:
           path: spec.template.spec.containers[0].env
-          content: {name: FF_MAX_COST_PER_WORKER, value: "9"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
           content: {name: FF_IO_THREADS, value: "5"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_THREADS, value: "6"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_MEMORY_LIMIT, value: 3Gi}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_TARGET_PARTITIONS, value: "4"}
         documentSelector: *deployment
       - contains:
           path: spec.template.spec.containers[0].env
@@ -60,17 +40,9 @@ tests:
     templates:
       - templates/logfire-ff-query-api.yaml
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_QUERY_PARALLELISM, value: auto}
-        documentSelector: *deployment
       - notContains:
           path: spec.template.spec.containers[0].env
           content: {name: FF_IO_THREADS}
-        documentSelector: *deployment
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_MEMORY_LIMIT}
         documentSelector: *deployment
       - contains:
           path: spec.template.spec.containers[0].env
@@ -81,10 +53,7 @@ tests:
     set:
       logfire-ff-query-worker:
         enabled: true
-        queryParallelism: "3"
         ioThreads: "2"
-        datafusionThreads: "4"
-        datafusionMemory: 5Gi
         resources:
           cpu: "2500m"
           memory: 6Gi
@@ -93,27 +62,11 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
-          content: {name: FF_QUERY_PARALLELISM, value: "3"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
           content: {name: FF_MAX_COST_PER_WORKER, value: "3"}
         documentSelector: *deployment
       - contains:
           path: spec.template.spec.containers[0].env
-          content: {name: FF_RESOURCE_CPU_CORES, value: "2.500"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
           content: {name: FF_IO_THREADS, value: "2"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_THREADS, value: "4"}
-        documentSelector: *deployment
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content: {name: FF_DATAFUSION_MEMORY_LIMIT, value: 5Gi}
         documentSelector: *deployment
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/logfire/tests/query_execution_test.yaml
+++ b/charts/logfire/tests/query_execution_test.yaml
@@ -1,0 +1,121 @@
+suite: FusionFire query execution settings
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+  dev:
+    deployPostgres: true
+tests:
+  - it: renders the complete execution environment for combined query intake
+    set:
+      logfire-ff-query-api:
+        queryParallelism: "7"
+        maxQueryCostPerPod: 9
+        ioThreads: "5"
+        datafusionThreads: "6"
+        datafusionMemory: 3Gi
+        datafusionTargetPartitions: 4
+        datafusionBatchSize: 2048
+    templates:
+      - templates/logfire-ff-query-api.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_QUERY_PARALLELISM, value: "7"}
+        documentSelector: &deployment
+          path: kind
+          value: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_MAX_COST_PER_WORKER, value: "9"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_IO_THREADS, value: "5"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_THREADS, value: "6"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_MEMORY_LIMIT, value: 3Gi}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_TARGET_PARTITIONS, value: "4"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_BATCH_SIZE, value: "2048"}
+        documentSelector: *deployment
+
+  - it: keeps DataFusion execution settings off remote query intake
+    set:
+      logfire-ff-query-worker:
+        enabled: true
+    templates:
+      - templates/logfire-ff-query-api.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_QUERY_PARALLELISM, value: auto}
+        documentSelector: *deployment
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_IO_THREADS}
+        documentSelector: *deployment
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_MEMORY_LIMIT}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_TLS_CLIENT_SNI_HOSTNAME, value: logfire-ff-query-worker}
+        documentSelector: *deployment
+
+  - it: renders the complete execution environment for a remote query worker
+    set:
+      logfire-ff-query-worker:
+        enabled: true
+        queryParallelism: "3"
+        ioThreads: "2"
+        datafusionThreads: "4"
+        datafusionMemory: 5Gi
+        resources:
+          cpu: "2500m"
+          memory: 6Gi
+    templates:
+      - templates/logfire-ff-query-worker.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_QUERY_PARALLELISM, value: "3"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_MAX_COST_PER_WORKER, value: "3"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_RESOURCE_CPU_CORES, value: "2.500"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_IO_THREADS, value: "2"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_THREADS, value: "4"}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_DATAFUSION_MEMORY_LIMIT, value: 5Gi}
+        documentSelector: *deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: {name: FF_PG_POOL_MAX_CONNECTIONS, value: "4"}
+        documentSelector: *deployment


### PR DESCRIPTION
## Summary

- deepen the FusionFire query execution module so it owns the complete query environment
- keep workload topology decisions in the query intake and remote worker adapters
- add a focused mode matrix for combined intake, remote intake, and remote execution
- document FusionFire query execution settings in the domain context

## Architecture

The module now hides query parallelism, worker cost, resource-derived settings, DataFusion tuning, and adapter-specific execution settings behind one interface. The query intake and remote query worker remain the two adapters at the seam.

This is a behavior-preserving refactor. Normalized Kubernetes objects are identical before and after for both combined and remote-worker modes.

## Validation

- `helm unittest charts/logfire` — 70 passed
- `helm lint charts/logfire --values charts/logfire/ci/ci-values.yaml`
- `./ci/check-version-stable-checksums.sh`
- normalized before/after manifest comparison for both query modes
