### PR TITLE
Deliver transactional email on self-hosted

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.43-rc.3
+version: 0.13.43-rc.4
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.43-rc.2
+version: 0.13.43-rc.3
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.43-rc.1
+version: 0.13.43-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.43-rc.1](https://img.shields.io/badge/Version-0.13.43--rc.1-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.43-rc.2](https://img.shields.io/badge/Version-0.13.43--rc.2-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -616,7 +616,6 @@ Before diving deeper, verify these common configuration issues:
 | serviceAccount.name | string | `""` | Name of the ServiceAccount. If not set and create is true, a name is generated using the fullname template. If create is false and this is not set, the default ServiceAccount is used. |
 | serviceAccountName | string | `"default"` | DEPRECATED: Use serviceAccount.name instead. Kept for backward compatibility. @deprecated |
 | sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `large`, `standard`, `small`, or `tiny` to apply built-in customer sizing defaults. |
-| smtp.enabled | bool | `false` | Deliver transactional email. Requires an image containing `logfire_task_runner`, which this chart's `appVersion` does not yet ship, so it is off by default and configuring `smtp.host` alone changes nothing. Turning it on without that image leaves `logfire-task-runner` in `CrashLoopBackOff`. When false the producers do not queue email and no runner is deployed, which is the same shape as leaving SMTP unconfigured. |
 | smtp.host | string | `nil` | SMTP server hostname |
 | smtp.password | string | `nil` | SMTP password. Can be a plain string or a map with valueFrom (e.g., secretKeyRef). |
 | smtp.port | int | `25` | SMTP server port |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.43-rc.2](https://img.shields.io/badge/Version-0.13.43--rc.2-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.43-rc.3](https://img.shields.io/badge/Version-0.13.43--rc.3-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -616,6 +616,7 @@ Before diving deeper, verify these common configuration issues:
 | serviceAccount.name | string | `""` | Name of the ServiceAccount. If not set and create is true, a name is generated using the fullname template. If create is false and this is not set, the default ServiceAccount is used. |
 | serviceAccountName | string | `"default"` | DEPRECATED: Use serviceAccount.name instead. Kept for backward compatibility. @deprecated |
 | sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `large`, `standard`, `small`, or `tiny` to apply built-in customer sizing defaults. |
+| smtp.enabled | bool | `true` | Deliver transactional email. When false the producers do not queue email and no `logfire-task-runner` is deployed, whatever `smtp.host` says. Set this false on an `appVersion` whose image predates `logfire_task_runner`, which would otherwise leave the runner in `CrashLoopBackOff`. |
 | smtp.host | string | `nil` | SMTP server hostname |
 | smtp.password | string | `nil` | SMTP password. Can be a plain string or a map with valueFrom (e.g., secretKeyRef). |
 | smtp.port | int | `25` | SMTP server port |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -616,7 +616,7 @@ Before diving deeper, verify these common configuration issues:
 | serviceAccount.name | string | `""` | Name of the ServiceAccount. If not set and create is true, a name is generated using the fullname template. If create is false and this is not set, the default ServiceAccount is used. |
 | serviceAccountName | string | `"default"` | DEPRECATED: Use serviceAccount.name instead. Kept for backward compatibility. @deprecated |
 | sizingPreset | string | `""` | Workload sizing preset. Leave empty to skip preset sizing, or set to `large`, `standard`, `small`, or `tiny` to apply built-in customer sizing defaults. |
-| smtp.enabled | bool | `true` | Deliver transactional email. When false the producers do not queue email and no `logfire-task-runner` is deployed, whatever `smtp.host` says. Set this false on an `appVersion` whose image predates `logfire_task_runner`, which would otherwise leave the runner in `CrashLoopBackOff`. |
+| smtp.enabled | bool | `false` | Deliver transactional email. Requires an image containing `logfire_task_runner`, which this chart's `appVersion` does not yet ship, so it is off by default and configuring `smtp.host` alone changes nothing. Turning it on without that image leaves `logfire-task-runner` in `CrashLoopBackOff`. When false the producers do not queue email and no runner is deployed, which is the same shape as leaving SMTP unconfigured. |
 | smtp.host | string | `nil` | SMTP server hostname |
 | smtp.password | string | `nil` | SMTP password. Can be a plain string or a map with valueFrom (e.g., secretKeyRef). |
 | smtp.port | int | `25` | SMTP server port |

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.43-rc.3](https://img.shields.io/badge/Version-0.13.43--rc.3-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
+![Version: 0.13.43-rc.4](https://img.shields.io/badge/Version-0.13.43--rc.4-informational?style=flat-square) ![AppVersion: 4ae3e48d](https://img.shields.io/badge/AppVersion-4ae3e48d-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -34,14 +34,6 @@ dev:
   deployMinio: true
   deployMaildev: true
 
-# maildev above still deploys, so its ingress rendering stays covered, but the email path
-# itself is off. `appVersion` predates the commit that added `logfire_task_runner`, so the
-# runner cannot start on the image this chart pins and `ct install` would fail waiting for
-# it. Drop this once `appVersion` advances past that commit, and the install test will
-# exercise the runner for real.
-smtp:
-  enabled: false
-
 postgresSecret:
   enabled: true
   name: "pg-dsns"

--- a/charts/logfire/ci/ci-values.yaml
+++ b/charts/logfire/ci/ci-values.yaml
@@ -34,6 +34,14 @@ dev:
   deployMinio: true
   deployMaildev: true
 
+# maildev above still deploys, so its ingress rendering stays covered, but the email path
+# itself is off. `appVersion` predates the commit that added `logfire_task_runner`, so the
+# runner cannot start on the image this chart pins and `ct install` would fail waiting for
+# it. Drop this once `appVersion` advances past that commit, and the install test will
+# exercise the runner for real.
+smtp:
+  enabled: false
+
 postgresSecret:
   enabled: true
   name: "pg-dsns"

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1478,12 +1478,27 @@ the dependency explicit rather than leaving it to scheduling order.
 */}}
 {{- define "logfire.absurdSchemaReady.initContainer" -}}
 - name: wait-for-absurd-schema
-  image: postgres:17
+  image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" "logfire-task-runner" "Chart" .Chart) }}'
+  imagePullPolicy: "{{ .Values.image.pullPolicy }}"
   command:
-    - sh
+    - python
     - -c
-    - >-
-      until psql "$CRUD_PG_DSN" -tAc "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'absurd'" | grep -q 1; do echo "Waiting for the absurd schema..."; sleep 2; done
+    - |
+      import os, time, psycopg
+
+      dsn = os.environ["CRUD_PG_DSN"]
+      while True:
+          try:
+              with psycopg.connect(dsn) as conn:
+                  found = conn.execute(
+                      "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'absurd'"
+                  ).fetchone()
+              if found:
+                  break
+              print("Waiting for the absurd schema...", flush=True)
+          except psycopg.OperationalError as exc:
+              print(f"Waiting for postgres: {exc}", flush=True)
+          time.sleep(2)
   env:
     - name: CRUD_PG_DSN
       valueFrom:

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1518,10 +1518,17 @@ the dependency explicit rather than leaving it to scheduling order.
   {{- $absurdInit = include "logfire.absurdSchemaReady.initContainer" $ctx | trim -}}
 {{- end -}}
 {{- $userHasCheckDbReady := dict "value" false -}}
+{{- $userHasAbsurdWait := dict "value" false -}}
 {{- range $userInit }}
   {{- if eq .name "check-db-ready" }}
     {{- $_ := set $userHasCheckDbReady "value" true -}}
   {{- end -}}
+  {{- if eq .name "wait-for-absurd-schema" }}
+    {{- $_ := set $userHasAbsurdWait "value" true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $userHasAbsurdWait.value -}}
+  {{- $absurdInit = "" -}}
 {{- end -}}
 {{- $includeDevInit := and $devInit (not $userHasCheckDbReady.value) -}}
 {{- if or $includeDevInit $userInit $absurdInit -}}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1469,11 +1469,39 @@ Dev Postgres helpers
 {{/*
 Merge initContainers from values with dev Postgres wait initContainer.
 */}}
+{{/*
+`logfire-task-runner` calls `absurd.create_queue()` before it serves, so it exits 1 and
+crash-loops until the `absurd` schema exists. That schema is installed by
+`logfire-backend-migrations`, which is only a Helm hook when the bundled Postgres is off
+(see the annotations on that Job), so nothing otherwise orders the two. Waiting here makes
+the dependency explicit rather than leaving it to scheduling order.
+*/}}
+{{- define "logfire.absurdSchemaReady.initContainer" -}}
+- name: wait-for-absurd-schema
+  image: postgres:17
+  command:
+    - sh
+    - -c
+    - >-
+      until psql "$CRUD_PG_DSN" -tAc "SELECT 1 FROM information_schema.schemata WHERE schema_name = 'absurd'" | grep -q 1; do echo "Waiting for the absurd schema..."; sleep 2; done
+  env:
+    - name: CRUD_PG_DSN
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "logfire.postgresSecretName" . }}
+          key: postgresDsn
+  {{- include "logfire.securityContext" .Values.securityContext | nindent 2 }}
+{{- end -}}
+
 {{- define "logfire.initContainers" -}}
 {{- $ctx := .ctx -}}
 {{- $serviceName := required "logfire.initContainers: serviceName is required" .serviceName -}}
 {{- $userInit := (index $ctx.Values $serviceName | default dict).initContainers -}}
 {{- $devInit := include "logfire.dev.waitForPostgres.initContainers" (dict "ctx" $ctx "serviceName" $serviceName) | trim -}}
+{{- $absurdInit := "" -}}
+{{- if eq $serviceName "logfire-task-runner" -}}
+  {{- $absurdInit = include "logfire.absurdSchemaReady.initContainer" $ctx | trim -}}
+{{- end -}}
 {{- $userHasCheckDbReady := dict "value" false -}}
 {{- range $userInit }}
   {{- if eq .name "check-db-ready" }}
@@ -1481,10 +1509,13 @@ Merge initContainers from values with dev Postgres wait initContainer.
   {{- end -}}
 {{- end -}}
 {{- $includeDevInit := and $devInit (not $userHasCheckDbReady.value) -}}
-{{- if or $includeDevInit $userInit -}}
+{{- if or $includeDevInit $userInit $absurdInit -}}
 initContainers:
 {{- if $includeDevInit }}
 {{ $devInit | nindent 2 }}
+{{- end }}
+{{- if $absurdInit }}
+{{ $absurdInit | nindent 2 }}
 {{- end }}
 {{- with $userInit }}
 {{ toYaml . | nindent 2 }}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1222,13 +1222,13 @@ In-cluster TLS helpers
 {{/*
 Whether this deployment has an SMTP server behind it, which is what decides if the producers
 queue transactional email at all. Derived from the SMTP configuration rather than a separate
-switch, so the two cannot disagree: `emails_enabled` without a reachable server would fill the
-queue with tasks that can only fail at delivery, and a configured server that no producer knows
-about sends nothing. `logfire-task-runner` is what drains that queue, so it is deployed on the
-same condition.
+switch, so the two cannot disagree: a configured server that no producer knows about sends
+nothing, and `emails_enabled` without a reachable server queues mail that can only fail at
+delivery. This gates the producers only. `logfire-task-runner` drains the Absurd queues and is
+deployed unconditionally, so queued email always has something behind it.
 */}}
 {{- define "logfire.emailsEnabled" -}}
-{{- if and (dig "enabled" true .Values.smtp) (or .Values.dev.deployMaildev .Values.smtp.host) -}}
+{{- if or .Values.dev.deployMaildev .Values.smtp.host -}}
 true
 {{- else -}}
 false

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1228,7 +1228,7 @@ about sends nothing. `logfire-task-runner` is what drains that queue, so it is d
 same condition.
 */}}
 {{- define "logfire.emailsEnabled" -}}
-{{- if or .Values.dev.deployMaildev .Values.smtp.host -}}
+{{- if and (dig "enabled" true .Values.smtp) (or .Values.dev.deployMaildev .Values.smtp.host) -}}
 true
 {{- else -}}
 false

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -1237,6 +1237,22 @@ In-cluster TLS helpers
 ================================================================================
 */}}
 
+{{/*
+Whether this deployment has an SMTP server behind it, which is what decides if the producers
+queue transactional email at all. Derived from the SMTP configuration rather than a separate
+switch, so the two cannot disagree: `emails_enabled` without a reachable server would fill the
+queue with tasks that can only fail at delivery, and a configured server that no producer knows
+about sends nothing. `logfire-task-runner` is what drains that queue, so it is deployed on the
+same condition.
+*/}}
+{{- define "logfire.emailsEnabled" -}}
+{{- if or .Values.dev.deployMaildev .Values.smtp.host -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{- define "logfire.inClusterTls.enabled" -}}
 {{- .Values.inClusterTls.enabled | default false -}}
 {{- end -}}
@@ -1424,6 +1440,7 @@ Dev Postgres helpers
   "logfire-backend"
   "logfire-backend-auth"
   "logfire-worker"
+  "logfire-task-runner"
   "logfire-dex"
   "logfire-backend-migrations"
   "logfire-ff-migrations"

--- a/charts/logfire/templates/logfire-backend-auth.yaml
+++ b/charts/logfire/templates/logfire-backend-auth.yaml
@@ -122,6 +122,8 @@ spec:
               value: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "tokenRedis") }}
             - name: TOKEN_REDIS_PREFIX
               value: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
+            - name: EMAILS_ENABLED
+              value: {{ include "logfire.emailsEnabled" . | quote }}
             - name: FRONTEND_HOST
               value: {{ include "logfire.url" . | quote }}
             {{- with (include "logfire.intakeOauthResourceUrl" . | trim) }}

--- a/charts/logfire/templates/logfire-backend.yaml
+++ b/charts/logfire/templates/logfire-backend.yaml
@@ -242,6 +242,8 @@ spec:
               value: {{ .Values.logfireRegion | default "local" }}
             - name: KNOWN_LOGFIRE_REGIONS
               value: '[{"name": "local", "frontend_host": "{{ include "logfire.url" . }}", "api_host": "{{ include "logfire.url" . }}", "auth_host": "{{ include "logfire.url" . }}"}]'
+            - name: EMAILS_ENABLED
+              value: {{ include "logfire.emailsEnabled" . | quote }}
             - name: FRONTEND_HOST
               value: {{ include "logfire.url" . | quote }}
             {{- include "logfire.rateLimits" . | nindent 12 }}

--- a/charts/logfire/templates/logfire-task-runner.yaml
+++ b/charts/logfire/templates/logfire-task-runner.yaml
@@ -1,7 +1,5 @@
 {{- $serviceName := "logfire-task-runner" }}
 {{- if (include "logfire.emailsEnabled" . | eq "true") }}
-{{- include "logfire.validate.autoscaling" (dict "Values" .Values "serviceName" $serviceName) -}}
-{{- include "logfire.validate.pdb" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/logfire/templates/logfire-task-runner.yaml
+++ b/charts/logfire/templates/logfire-task-runner.yaml
@@ -1,4 +1,7 @@
-{{- $serviceName := "logfire-worker" }}
+{{- $serviceName := "logfire-task-runner" }}
+{{- if (include "logfire.emailsEnabled" . | eq "true") }}
+{{- include "logfire.validate.autoscaling" (dict "Values" .Values "serviceName" $serviceName) -}}
+{{- include "logfire.validate.pdb" (dict "Values" .Values "serviceName" $serviceName) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,7 +11,7 @@ metadata:
     {{- include "logfire.workloadLabels" (dict "Values" .Values "serviceName" $serviceName) | nindent 4 }}
     app.kubernetes.io/component: {{ $serviceName }}
   annotations:
-    {{- include "logfire.workloadAnnotations" (dict "Values" .Values "serviceName" $serviceName "secretSources" (list "postgres" "existing")) | nindent 4 }}
+    {{- include "logfire.workloadAnnotations" (dict "Values" .Values "serviceName" $serviceName "secretSources" (list "postgres")) | nindent 4 }}
 spec:
   {{- include "logfire.replicas" (dict "Values" .Values "serviceName" $serviceName) | nindent 2 }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -22,9 +25,6 @@ spec:
         {{- if or (not .Values.postgresSecret.enabled) (empty .Values.postgresSecret.annotations) }}
         {{- include "logfire.postgresSecretChecksumAnnotation" (dict "ctx" .) | nindent 8 }}
         {{- end }}
-        {{- if or (not .Values.existingSecret.enabled) (empty .Values.existingSecret.annotations) }}
-        {{- include "logfire.logfireSecretChecksumAnnotations" (dict "ctx" . "secrets" (list "logfire-unsubscribe-secret")) | nindent 8 }}
-        {{- end }}
         {{- include "logfire.podAnnotations" (dict "Values" .Values "serviceName" $serviceName) | nindent 8 }}
       labels:
         {{- include "logfire.selectorLabels" . | nindent 8 }}
@@ -34,31 +34,27 @@ spec:
       {{- include "logfire.standardPodSpecFields" (dict "ctx" . "serviceName" $serviceName) | nindent 6 }}
       containers:
         - name: {{ $serviceName }}
-          image: '{{ .Values.image.repository | default "" }}{{ .Values.image.workerImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $serviceName "Chart" .Chart) }}'
+          image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $serviceName "Chart" .Chart) }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           {{- include "logfire.securityContext" .Values.securityContext | nindent 10 }}
-          command: [ "python", "-m", "logfire_worker" ]
+          command: [ "python", "-m", "logfire_task_runner" ]
           ports:
-            - containerPort: 8003
+            - containerPort: 8005
+          # Liveness is process-only so a Postgres blip cannot crash-loop every pod at once;
+          # startup uses /health, which does reach the database.
           livenessProbe:
             httpGet:
               path: /health/live
-              port: 8003
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8003
+              port: 8005
           startupProbe:
             httpGet:
-              path: /health/live
-              port: 8003
+              path: /health
+              port: 8005
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 11
           env:
-            - name: MATERIALIZE_DASHBOARDS
-              value: "false"
             - name: LOGFIRE_SERVICE_NAME
               value: {{ $serviceName }}
             - name: LOGFIRE_SERVICE_VERSION
@@ -68,64 +64,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "logfire.postgresSecretName" . }}
                   key: postgresDsn
-            - name: SHARED_REDIS_DSN
-              value: {{ .Values.redisDsn }}
-            - name: TOKEN_REDIS_DSN
-              value: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "tokenRedis") }}
-            - name: TOKEN_REDIS_PREFIX
-              value: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
-            - name: REDIS_DSN
-              value: {{ .Values.redisDsn }}
-            - name: BACKEND_REDIS_DSN
-              value: {{ .Values.redisDsn }}
-            - name: OTEL_TRACES_SAMPLER
-              value: parentbased_traceidratio
-            - name: OTEL_TRACES_SAMPLER_ARG
-              value: "0.05"
-            - name: FUSIONFIRE_QUERY_HOST
-              value: "{{ include "logfire.scheme" . }}://logfire-ff-query-api"
-            - name: FUSIONFIRE_QUERY_PORT
-              value: "{{ include "logfire.port" (dict "port" 8011 "root" .) }}"
-            - name: FUSIONFIRE_INGEST_HOST
-              value: "{{ include "logfire.scheme" . }}://logfire-ff-ingest-processor"
-            - name: FUSIONFIRE_INGEST_PORT
-              value: "{{ include "logfire.port" (dict "port" 8012 "root" .) }}"
-            - name: FUSIONFIRE_CRUD_HOST
-              value: "{{ include "logfire.scheme" . }}://logfire-ff-crud-api"
-            - name: FUSIONFIRE_CRUD_PORT
-              value: "{{ include "logfire.port" (dict "port" 8011 "root" .) }}"
-            {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
-            - name: LOGFIRE_CA_PATH
-              value: /etc/logfire/incluster-ca/ca.crt
-            {{- end }}
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: {{ include "logfire.otelResourceAttributes" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | quote }}
             - name: COLLECTOR_OTLP_GRPC_HOST
               value: http://logfire-otel-collector:4317
-            - name: EMAILS_ENABLED
-              value: {{ include "logfire.emailsEnabled" . | quote }}
             - name: FRONTEND_HOST
               value: {{ include "logfire.url" . | quote }}
-            {{- with (include "logfire.aiModelEnv" (dict "root" $ "roles" (list "reasoning")) | trim) }}
-            {{- . | nindent 12 }}
-            {{- end }}
-            {{- with (include "logfire.aiProviderEnv" $ | trim) }}
-            {{- . | nindent 12 }}
-            {{- end }}
-            - name: UNSUBSCRIBE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "logfire.secretName" (dict "ctx" . "secretName" "logfire-unsubscribe-secret") }}
-                  key: logfire-unsubscribe-secret
-            - name: JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "logfire.secretName" (dict "ctx" . "secretName" "logfire-jwt-secret") }}
-                  key: logfire-jwt-secret
             - name: LOGFIRE_REGION
               value: {{ .Values.logfireRegion | default "local" }}
-            - name: KNOWN_LOGFIRE_REGIONS
-              value: '[{"name": "local", "frontend_host": "{{ include "logfire.url" . }}", "api_host": "{{ include "logfire.url" . }}", "auth_host": "{{ include "logfire.url" . }}"}]'
+            {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
+            - name: LOGFIRE_CA_PATH
+              value: /etc/logfire/incluster-ca/ca.crt
+            {{- end }}
             {{ if .Values.dev.deployMaildev }}
             - name: SMTP_SERVER
               value: logfire-maildev
@@ -162,3 +112,4 @@ spec:
       {{- end }}
 {{- template "logfire.autoscaler" (dict "Values" .Values "serviceName" $serviceName) }}
 {{- template "logfire.pdb" (dict "root" $ "serviceName" $serviceName) }}
+{{- end }}

--- a/charts/logfire/templates/logfire-task-runner.yaml
+++ b/charts/logfire/templates/logfire-task-runner.yaml
@@ -1,5 +1,4 @@
 {{- $serviceName := "logfire-task-runner" }}
-{{- if (include "logfire.emailsEnabled" . | eq "true") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -110,4 +109,3 @@ spec:
       {{- end }}
 {{- template "logfire.autoscaler" (dict "Values" .Values "serviceName" $serviceName) }}
 {{- template "logfire.pdb" (dict "root" $ "serviceName" $serviceName) }}
-{{- end }}

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -68,6 +68,8 @@ tests:
     set:
       smtp:
         host: smtp.example.com
+      image:
+        repository: my-registry.example/
     templates:
       - templates/logfire-task-runner.yaml
     asserts:
@@ -79,9 +81,14 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[?(@.name=="wait-for-absurd-schema")].command[2]
           pattern: schema_name = 'absurd'
+      # The wait runs on every install, air-gapped ones included, so it has to reuse the image
+      # the runner already needs rather than reaching for a second registry.
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="wait-for-absurd-schema")].image
+          pattern: "^my-registry\\.example/python-prod:"
 
-  # With the bundled Postgres the server wait comes first: psql cannot check for the schema
-  # until the server accepts connections at all.
+  # With the bundled Postgres the server wait comes first. The schema wait tolerates a
+  # server that is not up yet, but ordering it second keeps the failure legible.
   - it: the dev Postgres wait comes before the schema wait
     set:
       smtp:

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -105,6 +105,28 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: wait-for-absurd-schema
 
+  # Duplicate initContainer names make Kubernetes reject the Pod outright, so an operator who
+  # supplies their own wait must replace ours rather than collide with it. Same guard the chart
+  # already gives `check-db-ready`.
+  - it: an operator supplied wait replaces the generated one
+    set:
+      smtp:
+        host: smtp.example.com
+      logfire-task-runner:
+        initContainers:
+          - name: wait-for-absurd-schema
+            image: my-own-image:1
+            command: ["true"]
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: my-own-image:1
+
   # The runner is the only workload that delivers these emails, so it needs the credentials
   # rather than just the producers' enable flag.
   - it: the runner receives the SMTP credentials and the database

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -1,0 +1,148 @@
+suite: transactional email delivery
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+tests:
+  # Without SMTP nothing downstream can deliver, so the producers must not queue and there is
+  # nothing for a runner to drain. Deploying one anyway would idle against an empty queue.
+  - it: no SMTP deploys no task runner and leaves the producers queueing nothing
+    templates:
+      - templates/logfire-task-runner.yaml
+      - templates/logfire-backend.yaml
+      - templates/logfire-backend-auth.yaml
+      - templates/logfire-worker.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/logfire-task-runner.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-backend.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-worker.yaml
+
+  # The queue only drains if something runs `logfire_task_runner`; without this deployment a
+  # self-hosted install queues transactional email that is never delivered.
+  - it: configuring SMTP deploys the runner that drains the queue
+    set:
+      smtp:
+        host: smtp.example.com
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: logfire-task-runner
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["python", "-m", "logfire_task_runner"]
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8005
+      # Liveness must not touch the database, or one Postgres blip restarts every pod at once.
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/live
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+
+  # The runner is the only workload that delivers these emails, so it needs the credentials
+  # rather than just the producers' enable flag.
+  - it: the runner receives the SMTP credentials and the database
+    set:
+      smtp:
+        host: smtp.example.com
+        port: 587
+        username: mailer
+        password: hunter2
+        use_tls: true
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_SERVER
+            value: smtp.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_PORT
+            value: "587"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_USE_TLS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CRUD_PG_DSN
+            valueFrom:
+              secretKeyRef:
+                name: lf-logfire-pg
+                key: postgresDsn
+
+  # A producer that queues while `EMAILS_ENABLED` is false would drop the email silently, so the
+  # flag has to follow the same condition that deploys the runner.
+  - it: configuring SMTP turns the producers on
+    set:
+      smtp:
+        host: smtp.example.com
+    templates:
+      - templates/logfire-backend.yaml
+      - templates/logfire-backend-auth.yaml
+      - templates/logfire-worker.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "true"
+        template: templates/logfire-backend.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "true"
+        template: templates/logfire-backend-auth.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "true"
+        template: templates/logfire-worker.yaml
+
+  # The dev overlay points at maildev instead of a real server, and has to reach the same state.
+  - it: the maildev overlay deploys the runner pointed at maildev
+    set:
+      dev:
+        deployMaildev: true
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: logfire-task-runner
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_SERVER
+            value: logfire-maildev

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -38,6 +38,7 @@ tests:
   - it: configuring SMTP deploys the runner that drains the queue
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
     templates:
       - templates/logfire-task-runner.yaml
@@ -67,6 +68,7 @@ tests:
   - it: the runner waits for the absurd schema before starting
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
       image:
         repository: my-registry.example/
@@ -92,6 +94,7 @@ tests:
   - it: the dev Postgres wait comes before the schema wait
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
       dev:
         deployPostgres: true
@@ -111,6 +114,7 @@ tests:
   - it: an operator supplied wait replaces the generated one
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
       logfire-task-runner:
         initContainers:
@@ -132,6 +136,7 @@ tests:
   - it: the runner receives the SMTP credentials and the database
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
         port: 587
         username: mailer
@@ -169,6 +174,7 @@ tests:
   - it: configuring SMTP turns the producers on
     set:
       smtp:
+        enabled: true
         host: smtp.example.com
     templates:
       - templates/logfire-backend.yaml
@@ -199,6 +205,8 @@ tests:
   # The dev overlay points at maildev instead of a real server, and has to reach the same state.
   - it: the maildev overlay deploys the runner pointed at maildev
     set:
+      smtp:
+        enabled: true
       dev:
         deployMaildev: true
     templates:
@@ -214,13 +222,13 @@ tests:
             name: SMTP_SERVER
             value: logfire-maildev
 
-  # An operator whose image predates `logfire_task_runner` needs a way to configure SMTP without
-  # crash-looping the runner. `smtp.enabled: false` turns the whole path off, producers included,
-  # rather than leaving them queueing onto a queue nothing drains.
-  - it: smtp.enabled false turns the path off despite a configured server
+  # The default is off, so an existing install that already sets `smtp.host` does not acquire a
+  # runner just by upgrading to this chart. Its image predates `logfire_task_runner` and would
+  # only crash-loop. The whole path goes off together, producers included, rather than leaving
+  # them queueing onto a queue nothing drains.
+  - it: delivery is off by default even with a configured server
     set:
       smtp:
-        enabled: false
         host: smtp.example.com
     templates:
       - templates/logfire-task-runner.yaml
@@ -252,11 +260,10 @@ tests:
             value: "false"
         template: templates/logfire-worker.yaml
 
-  # The dev overlay is the shape CI installs, so it has to honour the same switch.
-  - it: smtp.enabled false also turns off the maildev overlay
+  # The dev overlay is the shape CI installs, including the previous revision `ct` upgrades from,
+  # so it has to default off too.
+  - it: delivery is off by default under the maildev overlay
     set:
-      smtp:
-        enabled: false
       dev:
         deployMaildev: true
     templates:

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -60,6 +60,44 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /health
 
+  # The runner calls absurd.create_queue() before it serves and exits 1 until that schema
+  # exists, so without this wait it crash-loops against a database the migrations Job has not
+  # reached yet. That Job is only a Helm hook when the bundled Postgres is off, so nothing
+  # else orders the two.
+  - it: the runner waits for the absurd schema before starting
+    set:
+      smtp:
+        host: smtp.example.com
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-absurd-schema
+          any: true
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="wait-for-absurd-schema")].command[2]
+          pattern: schema_name = 'absurd'
+
+  # With the bundled Postgres the server wait comes first: psql cannot check for the schema
+  # until the server accepts connections at all.
+  - it: the dev Postgres wait comes before the schema wait
+    set:
+      smtp:
+        host: smtp.example.com
+      dev:
+        deployPostgres: true
+    templates:
+      - templates/logfire-task-runner.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: check-db-ready
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-absurd-schema
+
   # The runner is the only workload that delivers these emails, so it needs the credentials
   # rather than just the producers' enable flag.
   - it: the runner receives the SMTP credentials and the database

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -7,17 +7,20 @@ set:
   objectStore:
     uri: s3://test-bucket
 tests:
-  # Without SMTP nothing downstream can deliver, so the producers must not queue and there is
-  # nothing for a runner to drain. Deploying one anyway would idle against an empty queue.
-  - it: no SMTP deploys no task runner and leaves the producers queueing nothing
+  # The runner drains the Absurd queues generally, not just the email one, so it is deployed
+  # whether or not SMTP is configured. Without SMTP the producers still queue nothing, so the
+  # runner simply has no email to deliver.
+  - it: the runner is deployed even with no SMTP, and the producers queue nothing
     templates:
       - templates/logfire-task-runner.yaml
       - templates/logfire-backend.yaml
       - templates/logfire-backend-auth.yaml
       - templates/logfire-worker.yaml
     asserts:
-      - hasDocuments:
-          count: 0
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: logfire-task-runner
         template: templates/logfire-task-runner.yaml
       - contains:
           path: spec.template.spec.containers[0].env
@@ -38,7 +41,6 @@ tests:
   - it: configuring SMTP deploys the runner that drains the queue
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
     templates:
       - templates/logfire-task-runner.yaml
@@ -68,7 +70,6 @@ tests:
   - it: the runner waits for the absurd schema before starting
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
       image:
         repository: my-registry.example/
@@ -94,7 +95,6 @@ tests:
   - it: the dev Postgres wait comes before the schema wait
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
       dev:
         deployPostgres: true
@@ -114,7 +114,6 @@ tests:
   - it: an operator supplied wait replaces the generated one
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
       logfire-task-runner:
         initContainers:
@@ -136,7 +135,6 @@ tests:
   - it: the runner receives the SMTP credentials and the database
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
         port: 587
         username: mailer
@@ -174,7 +172,6 @@ tests:
   - it: configuring SMTP turns the producers on
     set:
       smtp:
-        enabled: true
         host: smtp.example.com
     templates:
       - templates/logfire-backend.yaml
@@ -205,8 +202,6 @@ tests:
   # The dev overlay points at maildev instead of a real server, and has to reach the same state.
   - it: the maildev overlay deploys the runner pointed at maildev
     set:
-      smtp:
-        enabled: true
       dev:
         deployMaildev: true
     templates:
@@ -222,60 +217,36 @@ tests:
             name: SMTP_SERVER
             value: logfire-maildev
 
-  # The default is off, so an existing install that already sets `smtp.host` does not acquire a
-  # runner just by upgrading to this chart. Its image predates `logfire_task_runner` and would
-  # only crash-loop. The whole path goes off together, producers included, rather than leaving
-  # them queueing onto a queue nothing drains.
-  - it: delivery is off by default even with a configured server
+  # There is no switch that removes the runner. It is core infrastructure for the Absurd queues,
+  # so disabling email must not take it with it, and a values file that tries is ignored rather
+  # than silently leaving the queues undrained.
+  - it: the runner survives an attempt to switch it off through smtp
     set:
       smtp:
+        enabled: false
         host: smtp.example.com
     templates:
       - templates/logfire-task-runner.yaml
-      - templates/logfire-backend.yaml
-      - templates/logfire-backend-auth.yaml
-      - templates/logfire-worker.yaml
     asserts:
-      - hasDocuments:
-          count: 0
-        template: templates/logfire-task-runner.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: EMAILS_ENABLED
-            value: "false"
-        template: templates/logfire-backend.yaml
-        documentIndex: 1
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: EMAILS_ENABLED
-            value: "false"
-        template: templates/logfire-backend-auth.yaml
-        documentIndex: 1
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: EMAILS_ENABLED
-            value: "false"
-        template: templates/logfire-worker.yaml
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: logfire-task-runner
 
-  # The dev overlay is the shape CI installs, including the previous revision `ct` upgrades from,
-  # so it has to default off too.
-  - it: delivery is off by default under the maildev overlay
-    set:
-      dev:
-        deployMaildev: true
+  # The runner needs the database whether or not it is delivering email, since that is how it
+  # reaches the Absurd queues at all.
+  - it: the runner gets the database even with no SMTP configured
     templates:
       - templates/logfire-task-runner.yaml
-      - templates/logfire-worker.yaml
     asserts:
-      - hasDocuments:
-          count: 0
-        template: templates/logfire-task-runner.yaml
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: EMAILS_ENABLED
-            value: "false"
-        template: templates/logfire-worker.yaml
+            name: CRUD_PG_DSN
+            valueFrom:
+              secretKeyRef:
+                name: lf-logfire-pg
+                key: postgresDsn
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["python", "-m", "logfire_task_runner"]

--- a/charts/logfire/tests/task_runner_test.yaml
+++ b/charts/logfire/tests/task_runner_test.yaml
@@ -213,3 +213,62 @@ tests:
           content:
             name: SMTP_SERVER
             value: logfire-maildev
+
+  # An operator whose image predates `logfire_task_runner` needs a way to configure SMTP without
+  # crash-looping the runner. `smtp.enabled: false` turns the whole path off, producers included,
+  # rather than leaving them queueing onto a queue nothing drains.
+  - it: smtp.enabled false turns the path off despite a configured server
+    set:
+      smtp:
+        enabled: false
+        host: smtp.example.com
+    templates:
+      - templates/logfire-task-runner.yaml
+      - templates/logfire-backend.yaml
+      - templates/logfire-backend-auth.yaml
+      - templates/logfire-worker.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/logfire-task-runner.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-backend.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-backend-auth.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-worker.yaml
+
+  # The dev overlay is the shape CI installs, so it has to honour the same switch.
+  - it: smtp.enabled false also turns off the maildev overlay
+    set:
+      smtp:
+        enabled: false
+      dev:
+        deployMaildev: true
+    templates:
+      - templates/logfire-task-runner.yaml
+      - templates/logfire-worker.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/logfire-task-runner.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EMAILS_ENABLED
+            value: "false"
+        template: templates/logfire-worker.yaml

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -897,6 +897,38 @@ logfire-remote-mcp:
 #     minAvailable: 1
 
 
+# -- Autoscaling & resources for the transactional-email task runner. Deployed only when SMTP is
+# configured (`smtp.host`, or `dev.deployMaildev`), which is the same condition that makes the
+# producers queue email at all.
+# logfire-task-runner:
+#   # -- Workload labels
+#   labels: {}
+#   # -- Workload annotations
+#   annotations: {}
+#   # -- Pod labels
+#   podLabels: {}
+#   # -- Pod annotations
+#   podAnnotations: {}
+#   replicas: 1
+#   resources:
+#     cpu: "100m"
+#     memory: "256Mi"
+#     ephemeralStorage: "512Mi"
+#   autoscaling:
+#     minReplicas: 1
+#     maxReplicas: 3
+#     hpa:
+#       enabled: true
+#       memAverage: 65
+#       cpuAverage: 70
+#   nodeSelector: {}
+#   affinity: {}
+#   tolerations: []
+#   pdb:
+#     maxUnavailable: 1
+#     minAvailable: 1
+
+
 # -- Autoscaling & resources for the proxy pods
 # logfire-service:
 #   # -- Workload labels
@@ -1948,6 +1980,23 @@ sizingPresets:
           cpuAverage: 60
       pdb:
         maxUnavailable: 1
+    logfire-task-runner:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+          ephemeral-storage: "512Mi"
+        limits:
+          memory: "512Mi"
+          ephemeral-storage: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          cpuAverage: 70
+      pdb:
+        maxUnavailable: 1
     logfire-worker:
       resources:
         requests:
@@ -2237,6 +2286,23 @@ sizingPresets:
           enabled: true
           memAverage: 70
           cpuAverage: 60
+      pdb:
+        maxUnavailable: 1
+    logfire-task-runner:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+          ephemeral-storage: "512Mi"
+        limits:
+          memory: "512Mi"
+          ephemeral-storage: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          cpuAverage: 70
       pdb:
         maxUnavailable: 1
     logfire-worker:
@@ -2669,6 +2735,23 @@ sizingPresets:
           labelSelector:
             matchLabels:
               app.kubernetes.io/component: logfire-frontend-service
+    logfire-task-runner:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+          ephemeral-storage: "512Mi"
+        limits:
+          memory: "512Mi"
+          ephemeral-storage: "512Mi"
+      autoscaling:
+        minReplicas: 1
+        maxReplicas: 3
+        hpa:
+          enabled: true
+          cpuAverage: 70
+      pdb:
+        maxUnavailable: 1
     logfire-worker:
       resources:
         requests:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -65,7 +65,7 @@ ingress:
   # -- Enable the Ingress resource.
   # If you are NOT using an ingress resource, you still need to set `tls` and `hostnames`
   # via either `ingress.*` or `gateway.*` so the application can generate correct URLs/CORS.
-  enabled: false
+  enabled: true
 
   # -- Enable TLS/HTTPS. Required for correct CORS behavior.
   tls: false
@@ -732,7 +732,7 @@ logfire-remote-mcp:
   # -- Enable the remote MCP service. When disabled, the deployment is not
   # rendered and the `/mcp` and `/.well-known/oauth-protected-resource/mcp`
   # haproxy routes are removed.
-  enabled: false
+  enabled: true
 # logfire-remote-mcp:
 #   # -- Workload labels
 #   labels: {}
@@ -1524,7 +1524,7 @@ logfire-redis:
   # and simple self-contained installs. It is not highly available, and upgrades that
   # change its pod template cause a brief interruption while Redis is replaced.
   # For production, disable this and set redisDsn to a managed Redis endpoint.
-  enabled: false
+  enabled: true
 
   # -- Redis image configuration
   image:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -65,7 +65,7 @@ ingress:
   # -- Enable the Ingress resource.
   # If you are NOT using an ingress resource, you still need to set `tls` and `hostnames`
   # via either `ingress.*` or `gateway.*` so the application can generate correct URLs/CORS.
-  enabled: true
+  enabled: false
 
   # -- Enable TLS/HTTPS. Required for correct CORS behavior.
   tls: false
@@ -278,11 +278,12 @@ postgresFFDsn: "postgresql://postgres:postgres@logfire-postgres:5432/ff"
 # ==============================================================================
 
 smtp:
-  # -- Deliver transactional email. When false the producers do not queue email and no
-  # `logfire-task-runner` is deployed, whatever `smtp.host` says. Set this false on an
-  # `appVersion` whose image predates `logfire_task_runner`, which would otherwise leave
-  # the runner in `CrashLoopBackOff`.
-  enabled: true
+  # -- Deliver transactional email. Requires an image containing `logfire_task_runner`, which
+  # this chart's `appVersion` does not yet ship, so it is off by default and configuring
+  # `smtp.host` alone changes nothing. Turning it on without that image leaves
+  # `logfire-task-runner` in `CrashLoopBackOff`. When false the producers do not queue email
+  # and no runner is deployed, which is the same shape as leaving SMTP unconfigured.
+  enabled: false
   # -- SMTP server hostname
   host:
   # -- SMTP server port
@@ -731,7 +732,7 @@ logfire-remote-mcp:
   # -- Enable the remote MCP service. When disabled, the deployment is not
   # rendered and the `/mcp` and `/.well-known/oauth-protected-resource/mcp`
   # haproxy routes are removed.
-  enabled: true
+  enabled: false
 # logfire-remote-mcp:
 #   # -- Workload labels
 #   labels: {}
@@ -1523,7 +1524,7 @@ logfire-redis:
   # and simple self-contained installs. It is not highly available, and upgrades that
   # change its pod template cause a brief interruption while Redis is replaced.
   # For production, disable this and set redisDsn to a managed Redis endpoint.
-  enabled: true
+  enabled: false
 
   # -- Redis image configuration
   image:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -278,6 +278,11 @@ postgresFFDsn: "postgresql://postgres:postgres@logfire-postgres:5432/ff"
 # ==============================================================================
 
 smtp:
+  # -- Deliver transactional email. When false the producers do not queue email and no
+  # `logfire-task-runner` is deployed, whatever `smtp.host` says. Set this false on an
+  # `appVersion` whose image predates `logfire_task_runner`, which would otherwise leave
+  # the runner in `CrashLoopBackOff`.
+  enabled: true
   # -- SMTP server hostname
   host:
   # -- SMTP server port

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -278,12 +278,6 @@ postgresFFDsn: "postgresql://postgres:postgres@logfire-postgres:5432/ff"
 # ==============================================================================
 
 smtp:
-  # -- Deliver transactional email. Requires an image containing `logfire_task_runner`, which
-  # this chart's `appVersion` does not yet ship, so it is off by default and configuring
-  # `smtp.host` alone changes nothing. Turning it on without that image leaves
-  # `logfire-task-runner` in `CrashLoopBackOff`. When false the producers do not queue email
-  # and no runner is deployed, which is the same shape as leaving SMTP unconfigured.
-  enabled: false
   # -- SMTP server hostname
   host:
   # -- SMTP server port
@@ -903,9 +897,9 @@ logfire-remote-mcp:
 #     minAvailable: 1
 
 
-# -- Autoscaling & resources for the transactional-email task runner. Deployed only when SMTP is
-# configured (`smtp.host`, or `dev.deployMaildev`), which is the same condition that makes the
-# producers queue email at all.
+# -- Autoscaling & resources for the Absurd task runner. Always deployed: it drains the Absurd
+# queues, which transactional email uses today and further features will use, so it does not
+# depend on SMTP being configured.
 # logfire-task-runner:
 #   # -- Workload labels
 #   labels: {}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on #225.** The Absurd task runner is now deployed unconditionally, and this chart's `appVersion: 4ae3e48d` predates the commit that ships `logfire_task_runner`, so `ct install` fails on every install until #225 moves `appVersion` to `28c6898b`. That is not fixable from this PR: an image without the module cannot run it. See "Version skew" below.

## Summary

Self-hosted installs get the Absurd task runner, and can send transactional email.

`logfire-task-runner` is deployed unconditionally. It drains the Absurd queues, which transactional email uses today and further features will use, so it is core infrastructure rather than an email component. This matches the managed deployment, where pydantic/platform#35817 removed the flag and deploys it always.

Configuring `smtp.host` turns the producers on; leaving SMTP unset means they queue nothing and the runner simply has no email to deliver.

## Upgrade notes

Upgrading deploys `logfire-task-runner`. **It requires an image containing `logfire_task_runner`**, i.e. one built after pydantic/platform#35567; on an older image it will sit in `CrashLoopBackOff`. The chart's `appVersion` will ship that image via #225.

Beyond the new workload, nothing changes unless you configure SMTP. With `smtp.host` unset the producers render `EMAILS_ENABLED: "false"`, matching the application default.

To send transactional email set `smtp.host` (plus `port`, `username`, `password`, `use_tls`). That sets `EMAILS_ENABLED=true` on `logfire-backend`, `logfire-backend-auth` and `logfire-worker`, which is what makes them queue it.

Sizing for the new workload is in the `tiny`, `small` and `standard` presets (100m CPU / 256Mi, matching the managed deployment); override it under a `logfire-task-runner:` key like any other workload.

Anyone who previously forced `EMAILS_ENABLED=true` through a workload's `env:` should drop that override and configure SMTP instead.

### Breaking changes

None, provided `appVersion` ships `logfire_task_runner`.

---

## What was wrong

`smtp.*` was plumbed through to `logfire-worker`, but nothing in the chart ever set `EMAILS_ENABLED`. That setting defaults to `false` in the application, so no producer queued anything and the SMTP values were inert: **a self-hosted install could not send transactional email at all, however it was configured.**

Forcing the flag through a workload's `env:` did not fix it either. The producers queue onto Absurd's `default` queue, and the chart had no workload that drains it, so email would be queued and never delivered.

## The approach

Two independent things, deliberately not coupled.

`logfire-task-runner` is always deployed. It mirrors the managed deployment: `python -m logfire_task_runner`, port 8005, liveness on `/health/live` and startup on `/health`. Liveness deliberately does not touch the database, so a Postgres blip cannot crash-loop every pod at once. It keeps its database wiring regardless of SMTP, since that is how it reaches the queues.

`logfire.emailsEnabled` gates the producers only, and is derived from the SMTP configuration rather than a separate switch, so the two cannot disagree: a configured server that no producer knows about sends nothing, and `emails_enabled` without a reachable server queues mail that can only fail at delivery. With the runner always present, the third bad state, producers queueing onto a queue nothing drains, is unreachable by construction.

An init container waits for the `absurd` schema before the runner starts. The runner calls `absurd.create_queue()` before it serves and exits 1 until that schema exists, and nothing otherwise orders it after `logfire-backend-migrations`: that Job only carries its `pre-install,pre-upgrade` hook annotations when the bundled Postgres is off, so under `dev.deployPostgres` it is an ordinary Job racing the deployments. It runs on the backend image the runner already uses, so no second registry is involved and air-gapped installs need nothing extra mirrored.

## Version skew

`appVersion: 4ae3e48d` is a platform commit from 2026-08-14. `logfire_task_runner` arrived in `d43ed6dc32` (pydantic/platform#35567) on 2026-08-25, which is not an ancestor of it, so the module does not exist in the image this chart ships.

While the runner was gated on SMTP this only bit when SMTP was configured, which included CI because `ci-values.yaml` sets `dev.deployMaildev: true`. Deploying it unconditionally means every install hits it, so `ct install` is red until the image catches up.

#225 is the fix and is open, green and mergeable: it moves `appVersion` to `28c6898b`, which contains both `d43ed6dc32` and `f822cb105a` (pydantic/platform#35817). Once it merges this branch takes main and CI exercises the runner for real. `appVersion` is not bumped here on purpose: it is owned by `logfire-helm-chart-automation[bot]`, keyed to a platform release rather than a main commit, and it drives the chart version too (see #207, #201, #225).

The chart version here is `0.13.43-rc.4` because #225 claims `rc.3`.

A correction to an earlier revision of this description: it claimed this worked against the image `appVersion` already pins. That was wrong. I had verified that the pinned image contains the Absurd schema install (it does) and mistakenly took that as covering the runner too.

## Validation

Run locally with the same toolchain CI uses (helm v4.2.0, helm-unittest v1.1.1):

- `helm unittest charts/logfire`: 65 passed across 10 suites, against 55 across 9 on `main` (measured in a clean worktree).
- The runner renders with no SMTP, with `smtp.host`, and under the maildev overlay, and `EMAILS_ENABLED` follows the SMTP configuration in each (`false`, `true`, `true`).
- The tests are discriminating: re-gating the runner on `emailsEnabled` fails exactly the two tests written for the new contract, and removing the runner template, the producer flag, the schema wait or the collision guard each fails others.
- Values `enabled` keys compared against `main` by parsing both files rather than by eye: 70 there, 73 here, differing only by the three `sizingPresets.*.logfire-task-runner.autoscaling.hpa.enabled` entries this branch adds.
- `helm lint` clean; `ci/check-version-stable-checksums.sh` exits 0; `helm-docs` reproduces the committed README.
- The schema wait was checked against a real Postgres 17 by extracting the rendered `command[2]` and running it: it proceeds on a schema-installed database, and keeps waiting on a bare database and an unreachable server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cc4GUyyjkZXUqGLAEGshZ