### PR TITLE
Move chart tests from Depot to GitHub runners

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: ubuntu-latest-16-cores
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Move the chart integration workflow from Depot to GitHub's 16-core Ubuntu larger runner.

The 16-core size preserves the current runner's 64 GB memory class, which the Kind deployment needs for the chart's `tiny` sizing preset. This intentionally prioritizes removing the repository's Depot dependency over per-minute compute price; the hosted run will provide the direct runtime comparison.

## Validation

- `actionlint -ignore SC2064 .github/workflows/pr.yaml`
- `git diff --check`

`SC2064` is an existing warning in the integration-test cleanup trap and is unchanged by this PR.
