### PR TITLE
Start the backend auth workload via logfire_auth.main

### DIFF
--- a/charts/logfire/templates/logfire-backend-auth.yaml
+++ b/charts/logfire/templates/logfire-backend-auth.yaml
@@ -59,7 +59,7 @@ spec:
         - name: {{ $serviceName }}
           image: '{{ .Values.image.repository | default "" }}{{ .Values.image.backendImage }}:{{ include "logfire.serviceTag" (dict "Values" .Values "serviceName" $imageTagOwner "Chart" .Chart) }}'
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          command: ["python", "-m", "logfire_backend.profiles.auth"]
+          command: ["python", "-m", "logfire_auth.main"]
           {{- include "logfire.securityContext" .Values.securityContext | nindent 10 }}
           {{- include "logfire.resources" (dict "Values" .Values "serviceName" $serviceName) | nindent 10 }}
           ports:

--- a/charts/logfire/tests/backend_auth_test.yaml
+++ b/charts/logfire/tests/backend_auth_test.yaml
@@ -25,7 +25,7 @@ tests:
           any: true
       - equal:
           path: spec.template.spec.containers[0].command
-          value: ["python", "-m", "logfire_backend.profiles.auth"]
+          value: ["python", "-m", "logfire_auth.main"]
         documentSelector:
           path: kind
           value: Deployment


### PR DESCRIPTION
## Summary

Fix the `logfire-backend-auth` workload crash-looping on current backend images: it is started with an entrypoint module that no longer exists.

The auth profile moved out of the monolith into the standalone `logfire-auth` package, so `python -m logfire_backend.profiles.auth` no longer resolves and the container exits with `ModuleNotFoundError: No module named 'logfire_backend.profiles'`. The package ships in the same image the chart already uses (the platform `Dockerfile` copies `src/services/logfire-auth`), and the platform's own deployment of this workload already runs `python -m logfire_auth.main`, so only the entrypoint module changes.

`charts/logfire/tests/backend_auth_test.yaml` pinned the old command, which is why the chart's tests did not catch this; the assertion is updated with it.

## Upgrade notes

None. Same image, same service, same port and environment: only the container's `command` changes. The workload starts instead of crash-looping, so an operator whose `logfire-backend-auth` pod was in `CrashLoopBackOff` will see it become ready after upgrading.

### Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcWSfcGkXHTeLTq4svah4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcWSfcGkXHTeLTq4svah4c)_