### PR TITLE
Fix backend migration telemetry endpoint

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.43-rc.3
+version: 0.13.43-rc.4
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.43-rc.3](https://img.shields.io/badge/Version-0.13.43--rc.3-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
+![Version: 0.13.43-rc.4](https://img.shields.io/badge/Version-0.13.43--rc.4-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/logfire-backend-migrations.yaml
+++ b/charts/logfire/templates/logfire-backend-migrations.yaml
@@ -48,6 +48,7 @@ spec:
           env:
             - name: LOGFIRE_SEND_TO_LOGFIRE
               value: "false"
+            {{- include "logfire.otlpExporterEnv" (dict "root" . "serviceName" $serviceName "codeWorkDir" "/app") | nindent 12 }}
             - name: ON_PREM
               value: "true"
             - name: CRUD_MIGRATIONS_RESPECT_AUTO_RUN_FLAG

--- a/charts/logfire/tests/backend_migrations_test.yaml
+++ b/charts/logfire/tests/backend_migrations_test.yaml
@@ -1,0 +1,28 @@
+suite: backend migrations
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+tests:
+  - it: exports migration telemetry to the in-cluster collector
+    templates:
+      - templates/logfire-backend-migrations.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COLLECTOR_OTLP_GRPC_HOST
+            value: http://logfire-otel-collector:4317
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_SERVICE_NAME
+            value: logfire-backend-migrations
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOGFIRE_SEND_TO_LOGFIRE
+            value: "false"


### PR DESCRIPTION
Route backend migration telemetry to the in-cluster collector instead of the OTLP localhost fallback.