### PR TITLE
Support Helm templating in objectStore.uri

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.43
+version: 0.13.44-rc.1
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.43](https://img.shields.io/badge/Version-0.13.43-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
+![Version: 0.13.44-rc.1](https://img.shields.io/badge/Version-0.13.44--rc.1-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -596,9 +596,9 @@ Before diving deeper, verify these common configuration issues:
 | minio.persistence.size | string | `"32Gi"` |  |
 | nodeSelector | object | `{}` | Node selector applied to all workloads |
 | objectStore | object | `{"env":{},"sseCKeyB64":null,"uri":null,"volumeMounts":[],"volumes":[]}` | Object storage details |
-| objectStore.env | object | `{}` | Additional environment variables for the object store connection |
+| objectStore.env | object | `{}` | Additional environment variables for the object store connection. String values support Helm templating. |
 | objectStore.sseCKeyB64 | string | `nil` | Opt-in S3 Server-Side Encryption with Customer-provided Keys (SSE-C). Base64-encoded 256-bit key applied to all S3 PUT/GET/HEAD/multipart/copy requests. Only used when the object store is S3. Can be a plain string or a map with valueFrom (e.g., secretKeyRef).  IMPORTANT: this MUST be set from day one on an empty bucket. Enabling it on a bucket that already contains FusionFire data will break all reads of the pre-existing objects. losing the key means losing the data — AWS does not store it. |
-| objectStore.uri | string | `nil` | URI for object storage (e.g., `s3://bucket`) |
+| objectStore.uri | string | `nil` | URI for object storage (e.g., `s3://bucket`). Supports Helm templating, e.g. `s3://logfire-{{ .Release.Name }}` to derive a bucket per release. |
 | objectStore.volumeMounts | list | `[]` | Volume mounts for object store credentials |
 | objectStore.volumes | list | `[]` | Volumes for object store credentials |
 | otelResourceAttributes | object | `{}` | Additional OTEL resource attributes to stamp onto internal telemetry emitted by Logfire workloads. These are merged on top of the chart defaults and can override them. Example:   deployment.environment.name: prod   service.namespace: logfire |

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -670,12 +670,15 @@ Create Postgres secret name
 
 {{- define "logfire.objectStoreEnv" -}}
 - name: FF_OBJECT_STORE_URI
-  value: {{ .Values.objectStore.uri }}
+  value: {{ tpl .Values.objectStore.uri . | quote }}
 {{- with .Values.objectStore.sseCKeyB64 }}
 - name: FF_S3_SSE_C_KEY_B64
 {{ include "logfire.envValue" (dict "value" . "quote" true) | indent 2 }}
 {{- end }}
 {{- range $key, $value := .Values.objectStore.env }}
+{{- if kindIs "string" $value }}
+{{- $value = tpl $value $ }}
+{{- end }}
 - name: {{ $key }}
 {{ include "logfire.envValue" (dict "value" $value "quote" (not (kindIs "map" $value)) "allowValueKey" true) | indent 2 }}
 {{- end }}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -670,7 +670,7 @@ Create Postgres secret name
 
 {{- define "logfire.objectStoreEnv" -}}
 - name: FF_OBJECT_STORE_URI
-  value: {{ tpl .Values.objectStore.uri . | quote }}
+  value: {{ tpl (.Values.objectStore.uri | default "") . | quote }}
 {{- with .Values.objectStore.sseCKeyB64 }}
 - name: FF_S3_SSE_C_KEY_B64
 {{ include "logfire.envValue" (dict "value" . "quote" true) | indent 2 }}

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -18,7 +18,7 @@ data:
   FF_TOKEN_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
   FF_USAGE_REDIS_DSN: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "usageRedis") }}
   FF_USAGE_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "usageRedis") | quote }}
-  FF_OBJECT_STORE_URI: {{ tpl .Values.objectStore.uri . | quote }}
+  FF_OBJECT_STORE_URI: {{ tpl (.Values.objectStore.uri | default "") . | quote }}
   FF_PG_TRANSACTION_TIMEOUT: "30s"
 {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
   FF_TLS_MODE: "allow"
@@ -91,7 +91,7 @@ metadata:
 data:
   FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
-  FF_FAILOVER_OBJECT_STORE_URI: {{ printf "%s/_ingest_failover" (tpl .Values.objectStore.uri .) | quote }}
+  FF_FAILOVER_OBJECT_STORE_URI: {{ printf "%s/_ingest_failover" (tpl (.Values.objectStore.uri | default "") .) | quote }}
   FF_INGEST_MAX_TIME_SKEW: "120s"
   FF_INGEST_MAX_FUTURE_TIME_DRIFT: "1h"
   FF_INGEST_MAX_PAST_TIME_DRIFT: "24h"

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -18,7 +18,7 @@ data:
   FF_TOKEN_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
   FF_USAGE_REDIS_DSN: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "usageRedis") }}
   FF_USAGE_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "usageRedis") | quote }}
-  FF_OBJECT_STORE_URI: {{ .Values.objectStore.uri }}
+  FF_OBJECT_STORE_URI: {{ tpl .Values.objectStore.uri . | quote }}
   FF_PG_TRANSACTION_TIMEOUT: "30s"
 {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
   FF_TLS_MODE: "allow"
@@ -91,7 +91,7 @@ metadata:
 data:
   FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
-  FF_FAILOVER_OBJECT_STORE_URI: {{ .Values.objectStore.uri }}/_ingest_failover
+  FF_FAILOVER_OBJECT_STORE_URI: {{ printf "%s/_ingest_failover" (tpl .Values.objectStore.uri .) | quote }}
   FF_INGEST_MAX_TIME_SKEW: "120s"
   FF_INGEST_MAX_FUTURE_TIME_DRIFT: "1h"
   FF_INGEST_MAX_PAST_TIME_DRIFT: "24h"

--- a/charts/logfire/tests/object_store_test.yaml
+++ b/charts/logfire/tests/object_store_test.yaml
@@ -1,0 +1,78 @@
+suite: objectStore configuration
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  dev:
+    deployPostgres: true
+tests:
+  - it: renders a plain objectStore.uri unchanged
+    set:
+      objectStore:
+        uri: s3://test-bucket
+    templates:
+      - templates/logfire-ff-config.yaml
+    asserts:
+      - equal:
+          path: data.FF_OBJECT_STORE_URI
+          value: s3://test-bucket
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-base-config
+      - equal:
+          path: data.FF_FAILOVER_OBJECT_STORE_URI
+          value: s3://test-bucket/_ingest_failover
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-ingest-config
+
+  - it: expands helm templates in objectStore.uri
+    set:
+      objectStore:
+        uri: "s3://logfire-{{ .Release.Name }}-{{ .Release.Namespace }}"
+    templates:
+      - templates/logfire-ff-config.yaml
+      - templates/logfire-ff-ingest.yaml
+    asserts:
+      - equal:
+          path: data.FF_OBJECT_STORE_URI
+          value: s3://logfire-lf-default
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-base-config
+        template: templates/logfire-ff-config.yaml
+      - equal:
+          path: data.FF_FAILOVER_OBJECT_STORE_URI
+          value: s3://logfire-lf-default/_ingest_failover
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-ingest-config
+        template: templates/logfire-ff-config.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_OBJECT_STORE_URI
+            value: s3://logfire-lf-default
+        documentSelector:
+          path: kind
+          value: StatefulSet
+        template: templates/logfire-ff-ingest.yaml
+
+  - it: expands helm templates in objectStore.env string values
+    set:
+      objectStore:
+        uri: s3://test-bucket
+        env:
+          AWS_ENDPOINT: "http://minio-{{ .Release.Name }}:9000"
+    templates:
+      - templates/logfire-ff-ingest.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_ENDPOINT
+            value: http://minio-lf:9000
+        documentSelector:
+          path: kind
+          value: StatefulSet

--- a/charts/logfire/tests/object_store_test.yaml
+++ b/charts/logfire/tests/object_store_test.yaml
@@ -27,6 +27,20 @@ tests:
           path: metadata.name
           value: logfire-ff-ingest-config
 
+  - it: renders without objectStore.uri when dev.deployMinio is enabled
+    set:
+      dev:
+        deployMinio: true
+    templates:
+      - templates/logfire-ff-config.yaml
+    asserts:
+      - equal:
+          path: data.FF_OBJECT_STORE_URI
+          value: ""
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-base-config
+
   - it: expands helm templates in objectStore.uri
     set:
       objectStore:

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -1380,7 +1380,8 @@ logfire-ff-cache-byte:
 
 # -- Object storage details
 objectStore:
-  # -- URI for object storage (e.g., `s3://bucket`)
+  # -- URI for object storage (e.g., `s3://bucket`). Supports Helm templating,
+  # e.g. `s3://logfire-{{ .Release.Name }}` to derive a bucket per release.
   uri:
   # -- Opt-in S3 Server-Side Encryption with Customer-provided Keys (SSE-C).
   # Base64-encoded 256-bit key applied to all S3 PUT/GET/HEAD/multipart/copy
@@ -1392,7 +1393,8 @@ objectStore:
   # pre-existing objects.
   # losing the key means losing the data — AWS does not store it.
   sseCKeyB64:
-  # -- Additional environment variables for the object store connection
+  # -- Additional environment variables for the object store connection.
+  # String values support Helm templating.
   env: {}
   # -- Volume mounts for object store credentials
   volumeMounts: []


### PR DESCRIPTION
## Summary
`objectStore.uri` and string values in `objectStore.env` now support Helm templating (e.g. `s3://logfire-{{ .Release.Name }}`), so one shared values file can derive a bucket per instance. Rendered values are also quoted, so templated URIs can no longer produce invalid manifests.

## Upgrade notes
None — plain URIs render exactly as before (now quoted, which is semantically identical).
### Breaking changes
A literal `{{` in `objectStore.uri` or an `objectStore.env` string value is now evaluated as a Helm template instead of passed through verbatim. No realistic object store URI contains one, and such values were already broken at runtime.