### PR TITLE
Validate resolved object store URIs and promote chart 0.13.44

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.44-rc.1
+version: 0.13.44
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.44-rc.1](https://img.shields.io/badge/Version-0.13.44--rc.1-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
+![Version: 0.13.44](https://img.shields.io/badge/Version-0.13.44-informational?style=flat-square) ![AppVersion: b3f4394e](https://img.shields.io/badge/AppVersion-b3f4394e-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers-validation.tpl
+++ b/charts/logfire/templates/_helpers-validation.tpl
@@ -7,11 +7,11 @@ when required values are missing or incorrectly configured.
 */}}
 
 {{/*
-Validate that objectStore.uri is configured (required for production)
+Validate that objectStore.uri resolves to a nonblank value (required for production)
 */}}
 {{- define "logfire.validate.objectStore" -}}
 {{- if not .Values.dev.deployMinio -}}
-  {{- if not .Values.objectStore.uri -}}
+  {{- if not (include "logfire.objectStoreUri" . | trim) -}}
     {{- fail "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead." -}}
   {{- end -}}
 {{- end -}}

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -668,9 +668,14 @@ Create Postgres secret name
 {{- end }}
 {{- end -}}
 
+{{/* Resolve the object store URI consistently for validation and consumers. */}}
+{{- define "logfire.objectStoreUri" -}}
+{{- tpl (.Values.objectStore.uri | default "") . -}}
+{{- end -}}
+
 {{- define "logfire.objectStoreEnv" -}}
 - name: FF_OBJECT_STORE_URI
-  value: {{ tpl (.Values.objectStore.uri | default "") . | quote }}
+  value: {{ include "logfire.objectStoreUri" . | quote }}
 {{- with .Values.objectStore.sseCKeyB64 }}
 - name: FF_S3_SSE_C_KEY_B64
 {{ include "logfire.envValue" (dict "value" . "quote" true) | indent 2 }}

--- a/charts/logfire/templates/logfire-ff-config.yaml
+++ b/charts/logfire/templates/logfire-ff-config.yaml
@@ -18,7 +18,7 @@ data:
   FF_TOKEN_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "tokenRedis") | quote }}
   FF_USAGE_REDIS_DSN: {{ include "logfire.redisDsnFor" (dict "root" . "valuesKey" "usageRedis") }}
   FF_USAGE_REDIS_PREFIX: {{ include "logfire.redisPrefixFor" (dict "root" . "valuesKey" "usageRedis") | quote }}
-  FF_OBJECT_STORE_URI: {{ tpl (.Values.objectStore.uri | default "") . | quote }}
+  FF_OBJECT_STORE_URI: {{ include "logfire.objectStoreUri" . | quote }}
   FF_PG_TRANSACTION_TIMEOUT: "30s"
 {{- if (include "logfire.inClusterTls.enabled" . | eq "true") }}
   FF_TLS_MODE: "allow"
@@ -91,7 +91,7 @@ metadata:
 data:
   FF_BACKEND_SERVICE_URL: "{{ include "logfire.scheme" . }}://logfire-backend-auth:{{ include "logfire.port" (dict "port" 8000 "root" .) }}"
   FF_REDIS_TAIL_DSN: {{ .Values.redisDsn }}
-  FF_FAILOVER_OBJECT_STORE_URI: {{ printf "%s/_ingest_failover" (tpl (.Values.objectStore.uri | default "") .) | quote }}
+  FF_FAILOVER_OBJECT_STORE_URI: {{ printf "%s/_ingest_failover" (include "logfire.objectStoreUri" .) | quote }}
   FF_INGEST_MAX_TIME_SKEW: "120s"
   FF_INGEST_MAX_FUTURE_TIME_DRIFT: "1h"
   FF_INGEST_MAX_PAST_TIME_DRIFT: "24h"

--- a/charts/logfire/tests/object_store_test.yaml
+++ b/charts/logfire/tests/object_store_test.yaml
@@ -90,3 +90,103 @@ tests:
         documentSelector:
           path: kind
           value: StatefulSet
+
+  - it: rejects empty template result in production
+    set:
+      objectStore:
+        uri: '{{ "" }}'
+    templates:
+      - templates/logfire-validate-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead."
+
+  - it: rejects missing value template result in production
+    set:
+      objectStore:
+        uri: '{{ .Values.missingBucket | default "" }}'
+    templates:
+      - templates/logfire-validate-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead."
+
+  - it: rejects whitespace template result in production
+    set:
+      objectStore:
+        uri: '{{ "   " }}'
+    templates:
+      - templates/logfire-validate-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead."
+
+  - it: rejects whitespace literal in production
+    set:
+      objectStore:
+        uri: "   "
+    templates:
+      - templates/logfire-validate-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead."
+
+  - it: rejects empty literal in production
+    set:
+      objectStore:
+        uri: ''
+    templates:
+      - templates/logfire-validate-config.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectStore.uri is required. Set objectStore.uri to your S3/Azure/GCS bucket URI (e.g., 's3://bucket-name' or 'az://container-name'). For local development, you can set dev.deployMinio=true instead."
+
+  - it: allows an empty template result with development MinIO
+    set:
+      dev:
+        deployMinio: true
+      objectStore:
+        uri: '{{ "" }}'
+    templates:
+      - templates/logfire-validate-config.yaml
+      - templates/logfire-ff-config.yaml
+    asserts:
+      - equal:
+          path: data.FF_OBJECT_STORE_URI
+          value: ""
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-base-config
+        template: templates/logfire-ff-config.yaml
+
+  - it: preserves a literal GCS URI
+    set:
+      objectStore:
+        uri: gs://tenant-app-data/logfire
+    templates:
+      - templates/logfire-ff-config.yaml
+      - templates/logfire-ff-ingest.yaml
+    asserts:
+      - equal:
+          path: data.FF_OBJECT_STORE_URI
+          value: gs://tenant-app-data/logfire
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-base-config
+        template: templates/logfire-ff-config.yaml
+      - equal:
+          path: data.FF_FAILOVER_OBJECT_STORE_URI
+          value: gs://tenant-app-data/logfire/_ingest_failover
+        documentSelector:
+          path: metadata.name
+          value: logfire-ff-ingest-config
+        template: templates/logfire-ff-config.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FF_OBJECT_STORE_URI
+            value: gs://tenant-app-data/logfire
+        documentSelector:
+          path: kind
+          value: StatefulSet
+        template: templates/logfire-ff-ingest.yaml


### PR DESCRIPTION
## Summary

Promote chart `0.13.44` with object store URI and environment value templating. Reject URI templates that resolve to a blank value in production.

## Upgrade notes

No actions required