### PR TITLE
Document the SLO alert-history index upgrade prerequisite

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.45-rc.1
+version: 0.13.46-rc.1
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.45-rc.1](https://img.shields.io/badge/Version-0.13.45--rc.1-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
+![Version: 0.13.46-rc.1](https://img.shields.io/badge/Version-0.13.46--rc.1-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 
@@ -177,6 +177,11 @@ https://logfire.example.com/logfire-meta/logfire-meta#token=LOGFIRE_META_FRONTEN
 For local evaluation with the port-forward above, use `http://localhost:8080/logfire-meta/logfire-meta#token=LOGFIRE_META_FRONTEND_TOKEN`.
 
 After you have access, create an invite link from **Settings** > **Invite** and assign the **Admin** organization role.
+
+## Upgrading
+
+Review the release's upgrade notes and the [upgrade prerequisites](https://github.com/pydantic/logfire-helm-chart/blob/main/charts/logfire/UPGRADING.md) before changing chart or image versions.
+The upgrade guide is also included as `UPGRADING.md` in the chart package.
 
 ## Configuration Notes
 

--- a/charts/logfire/README.md.gotmpl
+++ b/charts/logfire/README.md.gotmpl
@@ -179,6 +179,11 @@ For local evaluation with the port-forward above, use `http://localhost:8080/log
 
 After you have access, create an invite link from **Settings** > **Invite** and assign the **Admin** organization role.
 
+## Upgrading
+
+Review the release's upgrade notes and the [upgrade prerequisites](https://github.com/pydantic/logfire-helm-chart/blob/main/charts/logfire/UPGRADING.md) before changing chart or image versions.
+The upgrade guide is also included as `UPGRADING.md` in the chart package.
+
 ## Configuration Notes
 
 ### Hostnames and Exposure

--- a/charts/logfire/UPGRADING.md
+++ b/charts/logfire/UPGRADING.md
@@ -1,0 +1,123 @@
+# Upgrade prerequisites
+
+Read the release's upgrade notes before changing the chart or image version.
+Complete database prerequisites against the CRUD database, not the Fusionfire
+or Dex database. Keep image tags aligned with the chart's supported release.
+
+## Unreleased: SLO alert-history completion index
+
+This prerequisite applies to the upcoming completion-ordered SLO alert-history
+reader. No released chart version is identified yet. The release owner must
+identify the first affected chart and application version in its upgrade notes
+and link this procedure before shipping that reader.
+
+### When to build
+
+For an existing database, build and verify the index below **before upgrading**
+to the affected reader. The index is additive and works with the old reader.
+Do not treat a successful Helm upgrade as evidence that this prerequisite ran.
+
+For a fresh database, install normally so the automatic migrations create
+`logfire.alert_runs`, then build and verify the index immediately after schema
+bootstrap, before configuring SLOs or admitting customer traffic. There is no
+existing SLO history to migrate. Do not try to create the index before its table
+exists or add a pre-install check that would prevent schema bootstrap.
+
+The chart's backend migration job skips migrations marked for manual execution
+and has a 300-second deadline. This index's migration,
+`add_slo_alert_history_completion_index`, is manual because a concurrent index
+build over existing alert history can exceed that deadline. Do not disable
+`CRUD_MIGRATIONS_RESPECT_AUTO_RUN_FLAG` or run all outstanding manual migrations
+to install this one index.
+
+### Prepare a direct database session
+
+Arrange the build with your database operator. Confirm sufficient database disk
+and I/O capacity, allow for two scans of the alert-history table, and monitor
+the build and application latency. Concurrent builds permit ordinary writes
+but can wait for long-lived transactions, including read-only transactions.
+
+Use a dedicated `psql` session to the primary CRUD PostgreSQL database with
+table-owner permissions. Use a direct PostgreSQL endpoint, not a
+transaction-pooled endpoint. A repeated backend PID does not prove that a
+connection is session-affine. Make sure any connection proxy and administrative
+job allow the build to finish.
+
+Do not use `BEGIN`, `psql --single-transaction`, or another transaction wrapper:
+`CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` cannot run inside one.
+Enable `ON_ERROR_STOP` in `psql`. Use this session only for the build and close it
+afterwards, including on error, so the temporary timeout overrides cannot leak
+into other work.
+
+In that direct session, set the build's timeout policy:
+
+```sql
+\set ON_ERROR_STOP on
+SET lock_timeout = '45min';
+SET statement_timeout = 0;
+SELECT 'SET transaction_timeout = 0'
+WHERE current_setting('transaction_timeout', true) IS NOT NULL
+\gexec
+```
+
+The last statement disables PostgreSQL 17's [transaction timeout](https://www.postgresql.org/docs/17/runtime-config-client.html#GUC-TRANSACTION-TIMEOUT) when available
+and does nothing on versions without that setting. The 45-minute lock timeout
+bounds individual lock waits, not the total build duration. Review that bound
+against your longest transactions. A timeout or disconnect can leave an invalid
+index that must be repaired before retrying.
+
+### Inspect, build, and verify
+
+Inspect the exact index name before changing anything:
+
+```sql
+SELECT i.indisvalid, i.indisready, pg_get_indexdef(i.indexrelid) AS definition
+FROM pg_catalog.pg_index AS i
+WHERE i.indexrelid = to_regclass(
+    'logfire.alert_runs_alert_id_observed_at_window_max_idx'
+);
+```
+
+If there is no row, create the index:
+
+```sql
+CREATE INDEX CONCURRENTLY alert_runs_alert_id_observed_at_window_max_idx
+ON logfire.alert_runs
+(alert_id, COALESCE(run_finished_at, window_max) DESC, window_max DESC);
+```
+
+If the inspection returns a valid, ready index with this definition, do not
+rebuild it. If the definition differs, stop and resolve the name collision with
+your database operator. Do not remove an unrelated index.
+
+If an earlier interrupted attempt left the expected index invalid, first confirm
+that no build of this index is still running. Then drop only that invalid index
+in the same direct, timeout-configured session and retry the create statement:
+
+```sql
+DROP INDEX CONCURRENTLY logfire.alert_runs_alert_id_observed_at_window_max_idx;
+```
+
+Do not use `CREATE INDEX IF NOT EXISTS` as a repair: it leaves an invalid index
+in place. See PostgreSQL's [concurrent index build guidance](https://www.postgresql.org/docs/17/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY).
+After the build completes, rerun the inspection. Require exactly one
+row with `indisvalid = true`, `indisready = true`, and the expected definition
+before proceeding. Record that verification in the upgrade change record, then
+close the build session.
+
+### Complete the upgrade
+
+For an existing installation, upgrade the reader only after the verified build.
+For a fresh installation, finish the build before configuring SLOs or opening
+customer traffic. Check that SLO alert history loads after rollout.
+
+When the application version containing the named migration is available,
+arrange for it to be recorded through the supported administrative migration
+workflow. Its already-valid-index path does not rebuild the index or change
+session timeouts. The chart does not deploy the administrative service; contact
+your Pydantic support representative for that step and for any earlier pending
+manual migrations. Do not insert migration-history records by hand.
+
+If the reader must be rolled back, keep this additive index. The older reader
+can continue using the database, and keeping the index avoids another build on
+the next upgrade.


### PR DESCRIPTION
## Summary

Document the database-index prerequisite for the upcoming completion-ordered SLO alert-history reader.

This is a documentation-only companion: it adds a packaged upgrade guide and README link, with a chart-only prerelease bump from `0.13.45-rc.1` to `0.13.46-rc.1`. `appVersion` remains `49166f28`; image tags, workload templates, values, migration-runner settings, and deadlines are unchanged.

## Upgrade notes

The reader prerequisite is unreleased. Keep this PR in draft until the release owner identifies the first affected chart and application version in the reader release's upgrade notes. This chart-version bump does not claim to include that reader.

The guide distinguishes existing populated databases, which need the additive index built and verified before the reader upgrade, from fresh databases, which bootstrap their schema normally and then build the index before SLO configuration or customer traffic. It covers direct-session timeouts, interrupted-build recovery, validity and definition verification, supported migration bookkeeping, and keeping the index when rolling back the reader.

### Breaking changes

None in this documentation-only change. Revertible: reverting these documentation and chart-metadata changes does not modify database state or workload configuration.

## Validation

- Regenerated the README with the repository-pinned `helm-docs` v1.14.2 and checked the generated diff.
- Local pre-commit and pre-push documentation hooks passed on the exact four-file diff.
- `git diff --check` passed; reviewed the procedure against the chart's current migration-job configuration and PostgreSQL documentation.
- No database or cluster operations were performed for this companion. Helm integration tests, hosted CI, and deployments were not run or monitored; no claims are made about their results.
