### PR TITLE
Document safe worker rollout for independent SLO history

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.46-rc.1
+version: 0.13.46-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.46-rc.1](https://img.shields.io/badge/Version-0.13.46--rc.1-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
+![Version: 0.13.46-rc.2](https://img.shields.io/badge/Version-0.13.46--rc.2-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/UPGRADING.md
+++ b/charts/logfire/UPGRADING.md
@@ -4,6 +4,66 @@ Read the release's upgrade notes before changing the chart or image version.
 Complete database prerequisites against the CRUD database, not the Fusionfire
 or Dex database. Keep image tags aligned with the chart's supported release.
 
+## Unreleased: independently scheduled SLO history
+
+The upcoming independent SLO history scheduler changes the lock order used by
+history writers. Existing installations must disable and drain optional history
+before replacing worker images, then enable it only after all old writers have
+stopped. A normal rolling image update with history enabled is not sufficient.
+The release notes must identify the first affected application version before
+shipping it. These steps are separate from the alert-history index prerequisite
+below; follow both when the destination release requires both.
+
+### Existing installations
+
+1. Keep the currently installed application version and add this override to
+   your existing values file. Preserve any other entries in the worker's `env`
+   list, and keep live SLO evaluation enabled:
+
+   ```yaml
+   logfire-worker:
+     env:
+       - name: SLO_HISTORY_BACKFILL_ENABLED
+         value: "false"
+   ```
+
+2. Apply the values change using your normal controlled rollout, without
+   changing application images yet. The setting is read at process startup,
+   not dynamically. Verify every worker has restarted with optional history
+   disabled, all previous worker processes have stopped, and their in-flight
+   history queries and database transactions have drained. Check any additional
+   worker deployments or manually operated workers, not only the Helm-managed
+   Deployment. Do not use `SLOS_ENABLED=false`: live SLO evaluation should
+   continue during this procedure.
+3. Upgrade to the new release while retaining the explicit history override.
+   Allow the normal backend migration job to finish before new workers start.
+   It creates the additive `logfire.slo_history_backfill_state` table; new
+   workers require the table even with optional history disabled. Leave
+   `CRUD_MIGRATIONS_RESPECT_AUTO_RUN_FLAG` enabled. No manual migration or
+   modification of bucket rows is needed for this scheduler change.
+4. Verify all workers now use the corrected release and no old writers remain.
+   Confirm live SLO results still refresh. Set the history override to `"true"`
+   and roll out that configuration. Existing objectives may wait for their next
+   successful live evaluation before history becomes eligible; do not edit
+   stored status timestamps to accelerate it.
+5. Check history progress and failures, live evaluation freshness, database
+   contention, and interactive query availability. If these regress, disable
+   optional history through another controlled rollout and investigate. Record
+   the installed versions and the fleet/drain verification in the upgrade
+   change record.
+
+### Fresh installations and rollback
+
+A fresh installation has no old writer fleet. Let automatic schema bootstrap
+complete before starting workers, then use the normal history default.
+
+Before rolling back to an older worker implementation, disable optional history
+on the new fleet, replace its processes with that setting, and verify its
+in-flight history work has drained. Only then introduce old workers. Keep the
+additive state table and migration bookkeeping; do not delete history buckets
+or hand-edit admission timestamps. After the rollback fleet is consistent,
+restore the history configuration supported by that release.
+
 ## Unreleased: SLO alert-history completion index
 
 This prerequisite applies to the upcoming completion-ordered SLO alert-history


### PR DESCRIPTION
## Summary

Document the controlled worker rollout required by the upcoming independently
scheduled SLO history implementation. Keep live evaluation enabled while
disabling and draining optional history before changing writer implementations.
Cover initial installation, migration ordering, re-enabling history, and rollback.

This documentation layer builds on the upgrade guide introduced by #233 and
remains draft while that base and the corresponding application release are
being prepared. The release notes must identify the first affected application
version before it ships.

The existing worker environment override and automatic backend migration job
provide the required controls. No workload template, runtime default, application
image tag, or application version is changed. The chart prerelease version and
generated README badge advance together for the documentation package.

## Validation

- Reviewed the existing worker environment rendering and backend migration job.
- Regenerated the README with the repository-pinned helm-docs tool.
- The repository Helm Docs hook and `git diff --check` pass.
- No chart CI, cluster operation, deployment, or production database operation
  was run as part of this change.

Revertibility: revertible. Documentation and prerelease package metadata only;
application images and stored state are unchanged.
