### PR TITLE
Standardize resources on requests/limits and remove ingest caps

### DIFF
--- a/charts/logfire/Chart.yaml
+++ b/charts/logfire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.13.45-rc.1
+version: 0.13.45-rc.2
 name: logfire
 description: Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/README.md
+++ b/charts/logfire/README.md
@@ -1,6 +1,6 @@
 # logfire
 
-![Version: 0.13.45-rc.1](https://img.shields.io/badge/Version-0.13.45--rc.1-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
+![Version: 0.13.45-rc.2](https://img.shields.io/badge/Version-0.13.45--rc.2-informational?style=flat-square) ![AppVersion: 49166f28](https://img.shields.io/badge/AppVersion-49166f28-informational?style=flat-square)
 
 Helm chart for self-hosted Pydantic Logfire
 

--- a/charts/logfire/templates/_helpers-resources.tpl
+++ b/charts/logfire/templates/_helpers-resources.tpl
@@ -5,6 +5,43 @@ Resource Quantity Helpers
 Helpers for parsing/deriving CPU and memory quantities used by FF workloads.
 */}}
 
+{{- define "logfire.normalizeResources" -}}
+{{- $values := deepCopy .values -}}
+{{- $resources := get $values "resources" -}}
+{{- if and $resources (kindIs "map" $resources) -}}
+{{- $flat := dict -}}
+{{- range $key := list "cpu" "memory" -}}
+{{- if hasKey $resources $key -}}
+{{- $_ := set $flat $key (get $resources $key) -}}
+{{- $_ := unset $resources $key -}}
+{{- end -}}
+{{- end -}}
+{{- if $flat -}}
+{{- $requestsSpecified := hasKey $resources "requests" -}}
+{{- $limitsSpecified := hasKey $resources "limits" -}}
+{{- $requests := get $resources "requests" | default dict -}}
+{{- $limits := get $resources "limits" | default dict -}}
+{{- range $key := list "cpu" "memory" -}}
+{{- if hasKey $flat $key -}}
+{{- if not (hasKey $requests $key) -}}
+{{- $_ := set $requests $key (get $flat $key) -}}
+{{- end -}}
+{{- if and (not $limitsSpecified) (not (hasKey $limits $key)) -}}
+{{- $_ := set $limits $key (get $flat $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if or $requestsSpecified (not (empty $requests)) -}}
+{{- $_ := set $resources "requests" $requests -}}
+{{- end -}}
+{{- if or $limitsSpecified (not (empty $limits)) -}}
+{{- $_ := set $resources "limits" $limits -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $values | toJson -}}
+{{- end -}}
+
 {{/*
 Convert Kubernetes CPU quantity to millicores.
 Accepts values like 1, 0.5, 750m.

--- a/charts/logfire/templates/_helpers.tpl
+++ b/charts/logfire/templates/_helpers.tpl
@@ -109,6 +109,7 @@ Only sizing and portable availability keys are inherited from presets.
 {{- define "logfire.effectiveServiceValues" -}}
 {{- $serviceName := .serviceName -}}
 {{- $serviceValues := get .Values $serviceName | default dict -}}
+{{- $serviceValues = include "logfire.normalizeResources" (dict "values" $serviceValues) | fromJson -}}
 {{- $merged := dict -}}
 {{- $presetName := .Values.sizingPreset | default "" -}}
 {{- if $presetName -}}

--- a/charts/logfire/tests/resource_shape_test.yaml
+++ b/charts/logfire/tests/resource_shape_test.yaml
@@ -1,0 +1,100 @@
+suite: resource shape normalization
+release:
+  name: lf
+  namespace: default
+set:
+  adminEmail: test@example.com
+  objectStore:
+    uri: s3://test-bucket
+
+tests:
+  - it: legacy flat resources set requests and limits
+    set:
+      sizingPreset: standard
+      logfire-ff-ingest:
+        resources:
+          cpu: "750m"
+          memory: "3Gi"
+    templates:
+      - templates/logfire-ff-ingest.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 750m
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 3Gi
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 750m
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 3Gi
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: nested requests render without limits
+    set:
+      sizingPreset: standard
+      logfire-ff-ingest:
+        resources:
+          requests:
+            cpu: "250m"
+    templates:
+      - templates/logfire-ff-ingest.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+        documentSelector:
+          path: kind
+          value: StatefulSet
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits
+        documentSelector:
+          path: kind
+          value: StatefulSet
+
+  - it: legacy flat override keeps the migrated preset limits for untouched dimensions
+    set:
+      sizingPreset: standard
+      logfire-ff-crud-api:
+        resources:
+          cpu: "250m"
+    templates:
+      - templates/logfire-ff-crud-api.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 250m
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+        documentSelector:
+          path: kind
+          value: Deployment

--- a/charts/logfire/values.yaml
+++ b/charts/logfire/values.yaml
@@ -419,15 +419,14 @@ logfire-dex:
 
   # -- Resource requests/limits
   # resources:
-  #   cpu: "250m"
-  #   memory: "256Mi"
-  #   # requests:
-  #   #   cpu: "250m"
-  #   #   memory: "256Mi"
-  #   # limits:
-  #   #   cpu: "500m"
-  #   #   memory: "512Mi"
-  #   # If limits are omitted, they default to requests (Guaranteed QoS).
+  #   requests:
+  #     cpu: "250m"
+  #     memory: "256Mi"
+  #   limits:
+  #     cpu: "500m"
+  #     memory: "512Mi"
+  # Omit `limits` for uncapped pods. Legacy flat `cpu`/`memory` values set
+  # requests and limits to the same value.
 
   # autoscaling:
   #   minReplicas: 1
@@ -501,15 +500,16 @@ logfire-ff-ingest:
   # directFileSubmitConcurrency: 32
 
   # resources:
-  #   cpu: "1"
-  #   memory: "2Gi"
+  #   requests:
+  #     cpu: "1"
+  #     memory: "2Gi"
   # autoscaling:
   #   minReplicas: 2
   #   maxReplicas: 24
   #   hpa:
   #     enabled: true
   #     memAverage: 40
-  #     cpuAverage: 60
+  #     cpuAverage: 45
   #     behavior:
   #       scaleDown:
   #         stabilizationWindowSeconds: 300
@@ -1854,8 +1854,12 @@ sizingPresets:
   tiny:
     logfire-dex:
       resources:
-        cpu: "50m"
-        memory: "96Mi"
+        requests:
+          cpu: "50m"
+          memory: "96Mi"
+        limits:
+          cpu: "50m"
+          memory: "96Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 3
@@ -1866,16 +1870,19 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-ingest:
+      # Requests only, so a hash-pinned pod can burst instead of being
+      # CFS-throttled at a hard limit.
       resources:
-        cpu: "500m"
-        memory: "1Gi"
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 12
         hpa:
           enabled: true
           memAverage: 40
-          cpuAverage: 60
+          cpuAverage: 45
       pdb:
         maxUnavailable: 1
     logfire-ff-ingest-processor:
@@ -1965,8 +1972,12 @@ sizingPresets:
         storage: "1Gi"
     logfire-ff-crud-api:
       resources:
-        cpu: "100m"
-        memory: "192Mi"
+        requests:
+          cpu: "100m"
+          memory: "192Mi"
+        limits:
+          cpu: "100m"
+          memory: "192Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -1978,8 +1989,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-frontend-service:
       resources:
-        cpu: "50m"
-        memory: "96Mi"
+        requests:
+          cpu: "50m"
+          memory: "96Mi"
+        limits:
+          cpu: "50m"
+          memory: "96Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 3
@@ -2025,9 +2040,14 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ai-gateway:
       resources:
-        cpu: "100m"
-        memory: "256Mi"
-        ephemeralStorage: "1Gi"
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+          ephemeral-storage: "1Gi"
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
+          ephemeral-storage: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -2039,8 +2059,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-service:
       resources:
-        cpu: "250m"
-        memory: "256Mi"
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -2051,8 +2075,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-ff-cache-byte:
       resources:
-        cpu: "1"
-        memory: "6Gi"
+        requests:
+          cpu: "1"
+          memory: "6Gi"
+        limits:
+          cpu: "1"
+          memory: "6Gi"
       scratchVolume:
         storage: "1Gi"
       autoscaling:
@@ -2063,8 +2091,12 @@ sizingPresets:
           cpuAverage: 25
     logfire-ff-proxy-cache-byte:
       resources:
-        cpu: "150m"
-        memory: "256Mi"
+        requests:
+          cpu: "150m"
+          memory: "256Mi"
+        limits:
+          cpu: "150m"
+          memory: "256Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -2123,8 +2155,12 @@ sizingPresets:
         storage: "16Gi"
     logfire-otel-collector:
       resources:
-        cpu: "150m"
-        memory: "256Mi"
+        requests:
+          cpu: "150m"
+          memory: "256Mi"
+        limits:
+          cpu: "150m"
+          memory: "256Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -2137,8 +2173,12 @@ sizingPresets:
   small:
     logfire-dex:
       resources:
-        cpu: "100m"
-        memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 3
@@ -2149,16 +2189,19 @@ sizingPresets:
       pdb:
         maxUnavailable: 1
     logfire-ff-ingest:
+      # Requests only, so a hash-pinned pod can burst instead of being
+      # CFS-throttled at a hard limit.
       resources:
-        cpu: "500m"
-        memory: "1Gi"
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 12
         hpa:
           enabled: true
           memAverage: 40
-          cpuAverage: 60
+          cpuAverage: 45
       pdb:
         maxUnavailable: 1
       topologySpreadConstraints:
@@ -2273,8 +2316,12 @@ sizingPresets:
         storage: "2Gi"
     logfire-ff-crud-api:
       resources:
-        cpu: "125m"
-        memory: "256Mi"
+        requests:
+          cpu: "125m"
+          memory: "256Mi"
+        limits:
+          cpu: "125m"
+          memory: "256Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -2286,8 +2333,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-frontend-service:
       resources:
-        cpu: "100m"
-        memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 3
@@ -2352,8 +2403,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-service:
       resources:
-        cpu: "500m"
-        memory: "512Mi"
+        requests:
+          cpu: "500m"
+          memory: "512Mi"
+        limits:
+          cpu: "500m"
+          memory: "512Mi"
       autoscaling:
         minReplicas: 2
         maxReplicas: 6
@@ -2377,8 +2432,12 @@ sizingPresets:
               app.kubernetes.io/component: logfire-service
     logfire-ff-cache-byte:
       resources:
-        cpu: "1"
-        memory: "6Gi"
+        requests:
+          cpu: "1"
+          memory: "6Gi"
+        limits:
+          cpu: "1"
+          memory: "6Gi"
       scratchVolume:
         storage: "4Gi"
       autoscaling:
@@ -2389,8 +2448,12 @@ sizingPresets:
           cpuAverage: 25
     logfire-ff-proxy-cache-byte:
       resources:
-        cpu: "500m"
-        memory: "384Mi"
+        requests:
+          cpu: "500m"
+          memory: "384Mi"
+        limits:
+          cpu: "500m"
+          memory: "384Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 8
@@ -2449,8 +2512,12 @@ sizingPresets:
         storage: "32Gi"
     logfire-otel-collector:
       resources:
-        cpu: "250m"
-        memory: "512Mi"
+        requests:
+          cpu: "250m"
+          memory: "512Mi"
+        limits:
+          cpu: "250m"
+          memory: "512Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 4
@@ -2463,8 +2530,12 @@ sizingPresets:
   standard:
     logfire-dex:
       resources:
-        cpu: "100m"
-        memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 5
@@ -2490,16 +2561,21 @@ sizingPresets:
     logfire-ff-ingest:
       volumeClaimTemplates:
         storage: 16Gi
+      # Requests without limits: the ingest HAProxy backend consistent-hashes a
+      # tenant's Authorization + path to a single pod, and the HPA scales on the
+      # fleet average, so a pinned pod must be able to burst into spare node
+      # capacity instead of being CFS throttled at a hard limit.
       resources:
-        cpu: "1"
-        memory: "2Gi"
+        requests:
+          cpu: "1"
+          memory: "2Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 12
         hpa:
           enabled: true
           memAverage: 40
-          cpuAverage: 60
+          cpuAverage: 45
       pdb:
         maxUnavailable: 1
       topologySpreadConstraints:
@@ -2631,8 +2707,12 @@ sizingPresets:
               app.kubernetes.io/component: logfire-ai-gateway
     logfire-remote-mcp:
       resources:
-        cpu: "250m"
-        memory: "640Mi"
+        requests:
+          cpu: "250m"
+          memory: "640Mi"
+        limits:
+          cpu: "250m"
+          memory: "640Mi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 6
@@ -2694,8 +2774,12 @@ sizingPresets:
         storage: "6Gi"
     logfire-ff-crud-api:
       resources:
-        cpu: "125m"
-        memory: "512Mi"
+        requests:
+          cpu: "125m"
+          memory: "512Mi"
+        limits:
+          cpu: "125m"
+          memory: "512Mi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 6
@@ -2720,8 +2804,12 @@ sizingPresets:
               app.kubernetes.io/component: logfire-ff-crud-api
     logfire-frontend-service:
       resources:
-        cpu: "100m"
-        memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "100m"
+          memory: "128Mi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 5
@@ -2780,8 +2868,12 @@ sizingPresets:
         maxUnavailable: 1
     logfire-service:
       resources:
-        cpu: "1"
-        memory: "1Gi"
+        requests:
+          cpu: "1"
+          memory: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 6
@@ -2805,8 +2897,12 @@ sizingPresets:
               app.kubernetes.io/component: logfire-service
     logfire-ff-cache-byte:
       resources:
-        cpu: "1"
-        memory: "6Gi"
+        requests:
+          cpu: "1"
+          memory: "6Gi"
+        limits:
+          cpu: "1"
+          memory: "6Gi"
       autoscaling:
         minReplicas: 3
         maxReplicas: 24
@@ -2819,8 +2915,12 @@ sizingPresets:
         minAvailable: 2
     logfire-ff-proxy-cache-byte:
       resources:
-        cpu: "750m"
-        memory: "768Mi"
+        requests:
+          cpu: "750m"
+          memory: "768Mi"
+        limits:
+          cpu: "750m"
+          memory: "768Mi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 6
@@ -2879,8 +2979,12 @@ sizingPresets:
         storage: "64Gi"
     logfire-otel-collector:
       resources:
-        cpu: "1"
-        memory: "1Gi"
+        requests:
+          cpu: "1"
+          memory: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "1Gi"
       autoscaling:
         minReplicas: 1
         maxReplicas: 2


### PR DESCRIPTION
Presets and docs now use native `resources.requests`/`resources.limits`; legacy flat `cpu`/`memory` values are normalized on input and still set both the request and the limit. `logfire-ff-ingest` keeps requests without limits and its HPA CPU target drops from 60% to 45%.